### PR TITLE
Fix teapot conversion on vents/doors

### DIFF
--- a/Source/1.5/Comp/CompArchoHullConversion.cs
+++ b/Source/1.5/Comp/CompArchoHullConversion.cs
@@ -95,6 +95,17 @@ namespace SaveOurShip2
 						replacement.TryGetComp<CompAttachBase>().attachments.AddRange(new List<AttachableThing>(attachComp.attachments));
 						t.TryGetComp<CompAttachBase>().attachments.Clear();
 					}*/
+					CompTempControl tempComp = t.TryGetComp<CompTempControl>();
+                    if (tempComp != null) // ShipInside_PassiveVent or ShipInside_PassiveVentMechanoid atm, maintain temp and "use power" 
+                    {
+						replacement.TryGetComp<CompTempControl>().TargetTemperature = tempComp.TargetTemperature;
+                        ((Building_ShipVent)replacement).heatWithPower = ((Building_ShipVent)t).heatWithPower;
+					}
+					if (t.def.defName == "ShipAirlock" || t.def.defName == "ShipAirlockMech") //maintain "hold open"
+					{
+                        ((Building_ShipAirlock)replacement).holdOpenInt = ((Building_ShipAirlock)t).holdOpenInt;
+						
+					}
 					int shipIndex = mapComp.ShipIndexOnVec(parent.Position);
 					if (shipIndex > 0)
 					{


### PR DESCRIPTION
Have the archo conversion check for vents and transfer over heat/use power settings from the previous object (to prevent things like fridges warming) and door held open status (while I'm in here anyhow)