### PR TITLE
Made hostile drop pods land on critical ship buildings

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -1756,6 +1756,11 @@
 		<designationHotKey>Misc5</designationHotKey>
 		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
 		<rotatable>false</rotatable>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="BuildingBase">
 		<defName>Ship_LifeSupport_Small</defName>
@@ -1810,6 +1815,11 @@
 		<designationHotKey>Misc5</designationHotKey>
 		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
 		<rotatable>false</rotatable>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<!-- power -->
 	<DesignatorDropdownGroupDef>
@@ -1936,6 +1946,11 @@
 		<researchPrerequisites>
 			<li>ShipCapacitor</li>
 		</researchPrerequisites>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<DesignatorDropdownGroupDef>
 		<defName>Ship_Reactors</defName>
@@ -2029,6 +2044,11 @@
 		<staticSunShadowHeight>1.0</staticSunShadowHeight>
 		<designationHotKey>Misc4</designationHotKey>
 		<constructionSkillPrerequisite>12</constructionSkillPrerequisite>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="BuildingBase">
 		<defName>Ship_Reactor_Small</defName>
@@ -2119,6 +2139,11 @@
 		<staticSunShadowHeight>1.0</staticSunShadowHeight>
 		<designationHotKey>Misc4</designationHotKey>
 		<constructionSkillPrerequisite>12</constructionSkillPrerequisite>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<!-- bays -->
 	<DesignatorDropdownGroupDef>
@@ -2450,6 +2475,11 @@
 		</researchPrerequisites>
 		<designationHotKey>Misc1</designationHotKey>
 		<size>(3,3)</size>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<!-- crypto -->
 	<DesignatorDropdownGroupDef>
@@ -2800,6 +2830,11 @@
 		</costList>
 		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<!-- foam -->
 	<ThingDef ParentName="BuildingBase">

--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
@@ -130,6 +130,11 @@
 			<ComponentSpacer>12</ComponentSpacer>
 		</costList>
 		<seeThroughFog>true</seeThroughFog>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="BuildingBase">
 		<defName>ShipCombatShieldGeneratorMini</defName>
@@ -186,6 +191,11 @@
 			<ComponentSpacer>4</ComponentSpacer>
 		</costList>
 		<seeThroughFog>true</seeThroughFog>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="BuildingBase" Name="ShipHeatConduit">
 		<defName>ShipHeatConduit</defName>
@@ -409,6 +419,11 @@
 		<researchPrerequisites>
 			<li>ShipHeatsink</li>
 		</researchPrerequisites>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="ShipHeatsinkBase">
 		<defName>ShipHeatBankLarge</defName>
@@ -443,6 +458,11 @@
 		<researchPrerequisites>
 			<li>ShipHeatsink</li>
 		</researchPrerequisites>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="ShipHeatsinkBase">
 		<defName>ShipPurgePort</defName>
@@ -2039,6 +2059,11 @@
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<uiIconScale>0.9</uiIconScale>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="BuildingBase">
 		<defName>ShipSpinalAmplifier</defName>
@@ -2092,6 +2117,11 @@
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<uiIconScale>0.65</uiIconScale>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="ShipSpinalTurretBuilding">
 		<defName>ShipSpinalBarrelLaser</defName>

--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipTechArcho.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipTechArcho.xml
@@ -762,6 +762,11 @@
 			<li>ArchotechReactor</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>12</constructionSkillPrerequisite>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<!-- combat -->
 	<ThingDef ParentName="ShipHeatsinkBase">
@@ -865,6 +870,11 @@
 			<ArchotechExoticParticles>12</ArchotechExoticParticles>
 		</costList>
 		<seeThroughFog>true</seeThroughFog>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<!-- spore -->
 	<DesignatorDropdownGroupDef>
@@ -992,6 +1002,11 @@
 		<isAltar>true</isAltar>
 		<hasInteractionCell>True</hasInteractionCell>
 		<interactionCellOffset>(0,0, -1)</interactionCellOffset>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="BuildingBase">
 		<defName>ArchotechUplink</defName>
@@ -1108,6 +1123,11 @@
 			<li>BuildingsMisc</li>
 		</thingCategories>
 		<tradeability>Sellable</tradeability>
+        <modExtensions>
+            <li Class = "Vehicles.CustomCostDefModExtension">
+                <cost>10000</cost>
+            </li>
+        </modExtensions>
 	</ThingDef>
 	<ThingDef ParentName="ShipPillar">
 		<defName>ShipArchotechPillarA</defName>


### PR DESCRIPTION
Made it so the vehicle pathing cost too high for enemy drop pods to land on and destroy the ship's Cloaking Device, Life Support, Spore, shields, reactors, coolant tanks, or spinal weaponry. If the drop pod would land on those buildings it will instead be forced to the nearest open space.

Vehicle framework enabled drop pods to land on any passible, non-fence building by default with the only way to work around it is to forcible increase the vehicle pathing cost to traverse through the building.

The buildings were selected by how frustrating it would be if they were randomly destroyed. 