### PR TITLE
Fix: ships with <= 2000 mass don't require RCS thrusters to move,

### DIFF
--- a/Source/1.5/SpaceShipCache.cs
+++ b/Source/1.5/SpaceShipCache.cs
@@ -380,6 +380,8 @@ namespace SaveOurShip2
 		{
 			if (Engines.Any(e => e.Props.reactionless))
 				return true;
+			if (MassActual <= 2000 && Engines.Any(e => e.CanFire()))
+				return true;
 			return RCSs.Count > 0;
 		}
 		public float FuelNeeded(bool atmospheric)


### PR DESCRIPTION
like it was before change to HasRCS and like database ships are designed.