### PR TITLE
Vacuum speed multiplier cap. 

### DIFF
--- a/1.5/Defs/Stats/Stats_Pawns_General.xml
+++ b/1.5/Defs/Stats/Stats_Pawns_General.xml
@@ -35,6 +35,7 @@
     <defaultBaseValue>1</defaultBaseValue>
     <hideAtValue>1</hideAtValue>
     <minValue>0</minValue>
+	<maxValue>7</maxValue>
     <toStringStyle>PercentZero</toStringStyle>
     <displayPriorityInCategory>2002</displayPriorityInCategory>
   </StatDef>


### PR DESCRIPTION
Because vacuum speed multipliers from different sources stack, pawns can go absurdly fast in vacuum. Suggested cap is 700% So that when pawn  has both EVA suit and vacuum-adapted gene, they get 100% base, +400% from one thing and can only go up to 700%, not 900% because of other thing giving another +400%.
Some stacking is allowed because players like to make their pawns cool, and some allowed speed bonus looks fine, hauling resources left after deconstructing large ship is still a challenge. More strict solution would be to limit multiplier at 5 (500%).