### PR TITLE
Since sapient holodeck now includes AI core in recipie, should only be sellable to NPCs

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Joy.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Joy.xml
@@ -205,6 +205,7 @@
         <glowColor>(217,217,208,0)</glowColor>
       </li>
     </comps>
+    <tradeability>Sellable</tradeability>
     <tradeTags>
       <li>Television</li>
     </tradeTags>


### PR DESCRIPTION
…