### PR TITLE
Suggestion: Guaranteed cores/Mainfold yield from deconstruction.

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -2370,6 +2370,7 @@
 			<ComponentSpacer>12</ComponentSpacer>
 			<SoSEntanglementManifold>1</SoSEntanglementManifold>
 		</costList>
+		<resourcesFractionWhenDeconstructed>1</resourcesFractionWhenDeconstructed>
 		<comps>
 			<li Class="SaveOurShip2.CompProps_ShipCachePart"/>
 			<li Class="SaveOurShip2.CompProps_ShipBay">

--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipTechArcho.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipTechArcho.xml
@@ -1180,6 +1180,7 @@
 			<ComponentSpacer>8</ComponentSpacer>
 			<ArchotechPsychicCore>1</ArchotechPsychicCore>
 		</costList>
+		<resourcesFractionWhenDeconstructed>1</resourcesFractionWhenDeconstructed>
 		<comps>
 			<li Class="SaveOurShip2.CompProps_ShipCachePart">
 				<hermetic>true</hermetic>
@@ -1325,6 +1326,7 @@
 			<ComponentSpacer>8</ComponentSpacer>
 			<ArchotechMechaniteCore>1</ArchotechMechaniteCore>
 		</costList>
+		<resourcesFractionWhenDeconstructed>1</resourcesFractionWhenDeconstructed>
 		<comps>
 			<li Class="SaveOurShip2.CompProps_ShipCachePart">
 				<hermetic>true</hermetic>
@@ -1610,6 +1612,7 @@
 			<ComponentSpacer>6</ComponentSpacer>
 			<ArchotechMechaniteCore>1</ArchotechMechaniteCore>
 		</costList>
+		<resourcesFractionWhenDeconstructed>1</resourcesFractionWhenDeconstructed>
 		<altitudeLayer>Building</altitudeLayer>
 		<fillPercent>0.5</fillPercent>
 		<useHitPoints>True</useHitPoints>


### PR DESCRIPTION
Computer core always gives back AI Core on decon.
JT Drives return full cost on decon too, including Mainfolds. AS Glittertech salvage bay uses Entanglement Mainfold too, brought in line with JT drives, 100% decon yield.

As for Disassembler and Psychic Flayer spinal barrels and also Recyclotron, it is suggested to use 100% decon yield too. Because gambling important items on deconstruction looks like annoying mechanic.