### PR TITLE
For shuttle hovering over shutle bay, it will eat 1 fuel like very tick to refill 0.0x fuel spent by shuttle because of hovering. Suggested fix is to not refill hovering shuttle.

### DIFF
--- a/Source/1.5/Comp/CompShipBay.cs
+++ b/Source/1.5/Comp/CompShipBay.cs
@@ -178,7 +178,7 @@ namespace SaveOurShip2
 					ReCacheDockedShuttles();
 				foreach (CompFueledTravel comp in dockedShuttles)
 				{
-					if (compRefuelable.fuel > 0 && comp.FuelPercentOfTarget < 1)
+					if (compRefuelable.fuel > 0 && comp.FuelPercentOfTarget < 1 && !comp.Vehicle.ignition.Drafted)
 					{
 						comp.Refuel(1);
 						compRefuelable.ConsumeFuel(1);


### PR DESCRIPTION
 That will drain shuttle bay fuel like crazy if not fixed.
