### PR TITLE
Exploit fix: player could begin discarge of the JT drive at the impact site without claiming it.

### DIFF
--- a/1.5/Languages/English/Keyed/Letters.xml
+++ b/1.5/Languages/English/Keyed/Letters.xml
@@ -78,6 +78,7 @@
 	<SoS.HibernateWarningStandalone>The drive is ready to begin discharging its stored momentum. Once this is done, your colonists will be able to safely disassemble the drive and retrieve its Entanglement Manifold.\n\nThe process will take about 15 days, and the energy signature will be detectable from a long distance away. This sort of energy signature indicates interstellar flight capability, and will attract gangs of desperate raiders and swarms of deadly mechanoids.\n\nYou will be assaulted with an intensity you've never seen. Make sure your defenses are prepared first.</SoS.HibernateWarningStandalone>
     <SoS.CommandShipStartup>Begin discharge</SoS.CommandShipStartup>
     <SoS.CommandShipStartupDesc>Discharge the drive's stored momentum.</SoS.CommandShipStartupDesc>
+	<SoS.CommandShipStartupDisableReason>Claim the drive before discharging.</SoS.CommandShipStartupDisableReason>
 	<SoS.ImpactSiteLost>J-T drive destroyed</SoS.ImpactSiteLost>
 	<SoS.ImpactSiteLostDesc>An explosion rings out from the impact site.\n\nWithout properly completing the discharge process, the Johnson-Tanaka drive has torn itself apart. You'll need to find another drive to salvage.\n\nLuckily, the ancient ship had multiple engines - from its black box data, you are able to calculate another likely impact site.</SoS.ImpactSiteLostDesc>
 	<SoS.HibernateComplete>Discharge complete</SoS.HibernateComplete>

--- a/Source/1.5/Comp/CompHibernatableShip.cs
+++ b/Source/1.5/Comp/CompHibernatableShip.cs
@@ -133,6 +133,8 @@ namespace SaveOurShip2
 				discharge.defaultDesc = TranslatorFormattedStringExtensions.Translate("SoS.CommandShipStartupDesc");
 				discharge.hotKey = KeyBindingDefOf.Misc1;
 				discharge.icon = ContentFinder<Texture2D>.Get("UI/Commands/DesirePower", true);
+				discharge.disabled = parent.Faction != Faction.OfPlayer;
+				discharge.disabledReason = TranslatorFormattedStringExtensions.Translate("SoS.CommandShipStartupDisableReason");
 				gizmos.Add(discharge);
 			}
 			return gizmos;


### PR DESCRIPTION
And when JT drive is not player's property, raiders will not attack it - waay too easy.
Fix: require player to claim the JT drive before discharging.