### PR TITLE
Claim other faction vehicle on player pawn entering. Otherwise, that

### DIFF
--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4765,6 +4765,19 @@ namespace SaveOurShip2
 		}
 	}
 
+	// Temporary patch preventing losing control of player pawn that eneters enemy shuttle
+	[HarmonyPatch(typeof(VehiclePawn), "Notify_Boarded")]
+	public static class VehicleBoarded
+	{
+		public static void Postfix(VehiclePawn __instance, Pawn pawnToBoard, ref bool __result)
+		{
+			if (pawnToBoard.Faction == Faction.OfPlayer && __instance.Faction != Faction.OfPlayer && __result)
+			{
+				__instance.SetFaction(Faction.OfPlayer);
+			}
+		}
+	}
+
 	[HarmonyPatch(typeof(Corpse), "PostCorpseDestroy")]
 	public static class PreserveSoul
     {


### PR DESCRIPTION
results in player losing control over pawn until vehicle can be claimed which can be a problem