### PR TITLE
Backup check to fix moonbase bug

### DIFF
--- a/Source/1.5/ShipInteriorMod2.cs
+++ b/Source/1.5/ShipInteriorMod2.cs
@@ -641,7 +641,12 @@ namespace SaveOurShip2
 					return check.RandomElement();
 				ships.Where(def => !def.neverAttacks && !def.neverRandom && (allowNavyExc || !def.navyExclusive)).RandomElement();
 			}
-			return null;
+            Log.Warning($"SOS2: found no suitable enemy ship at all, very final fallback, allowNavyExc: {allowNavyExc}, randomFleet: {randomFleet}");
+            // final_final_2_usethis.docx check: Prevents NRE attacking moonbase, should be almost never reached otherwise: 
+            check = ships.Where(def => ValidShipDef(def, 0, 100000f, tradeShip, allowNavyExc, randomFleet, 0, minZ, maxZ)).ToList();
+            if (check.Any())
+                return check.RandomElement();
+            return null;
 		}
 		public static bool ValidShipDef(ShipDef def, float CRmin, float CRmax, bool tradeShip, bool allowNavyExc, bool randomFleet, int rarity = 0, int minZ = 0, int maxZ = 0)
 		{


### PR DESCRIPTION
Ships with very high CR can break the moonbase mission, this eventually falls back to simply any ship in the def at all. May catch other weird edge cases as well?

Considered removing the null return at the end as well but didn't check every use of RandomValidShipFrom thoroughly enough to be certain that was safe