### PR TITLE
Allow setling impact ste after JT drive quest is done.

### DIFF
--- a/Source/1.5/Comp/ImpactSiteComp.cs
+++ b/Source/1.5/Comp/ImpactSiteComp.cs
@@ -87,6 +87,11 @@ namespace SaveOurShip2
 				if(!foundDrive)
 					yield return SettlementAbandonUtility.AbandonCommand(mapParent);
 			}
+			// Allow settling impact site after drive quest is done
+			if (ShipInteriorMod2.WorldComp.Unlocks.Contains("JTDriveToo"))
+			{
+				yield return SettleInExistingMapUtility.SettleCommand(mapParent.Map, requiresNoEnemies: true);
+			}
 		}
 	}
 }


### PR DESCRIPTION
So it is like normal encounter maps, settle-able, and player does not have to deal with technical details of unsettled map if they want to continue the story with that site after quest.