### PR TITLE
Shuttles fixes

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
@@ -710,7 +710,7 @@
 			<drawSize>(2,2)</drawSize>
 		</graphicData>
 		<projectile>
-			<explosionRadius>1.1</explosionRadius>
+			<explosionRadius>0.9</explosionRadius>
 			<damageDef>BombACI</damageDef>
 			<speed>100</speed>
 		</projectile>

--- a/1.5/Defs/ThingDefs_Buildings/UpgradeTree.xml
+++ b/1.5/Defs/ThingDefs_Buildings/UpgradeTree.xml
@@ -1438,7 +1438,7 @@
 			<damageDef>ShipLaserSmall</damageDef>
 			<damageAmountBase>30</damageAmountBase>
 			<speed>800</speed>
-			<explosionRadius>1</explosionRadius>
+			<explosionRadius>0.5</explosionRadius>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 		</projectile>
 		<altitudeLayer>MetaOverlays</altitudeLayer>

--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4765,6 +4765,19 @@ namespace SaveOurShip2
 		}
 	}
 
+	[HarmonyPatch(typeof(CompUpgradeTree), "ValidateListers")]
+	public static class DisableValidateListersOffMap
+	{
+		public static bool Prefix(CompUpgradeTree __instance)
+		{
+			if( __instance.Vehicle.Map == null)
+			{
+				return false;
+			}
+			return true;
+		}
+	}
+
 	[HarmonyPatch(typeof(Corpse), "PostCorpseDestroy")]
 	public static class PreserveSoul
     {

--- a/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
+++ b/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
@@ -5,11 +5,101 @@ using System.Text;
 using UnityEngine;
 using Verse;
 using RimWorld;
+using Vehicles;
 
 namespace SaveOurShip2
 {
 	public class Projectile_ExplosiveShip : Projectile_Explosive
 	{
+		protected override void Impact(Thing hitThing, bool blockedByShield = false)
+		{
+			// Projectile position can be inaccurate by several tiles if it travels several tiles per tick, Verse issue
+			// The projectile will be "behind" actual hit location along it's trajectory. Like it had a proximity fuse or something.
+			// that affects ship weapon projectiles with high speed, but lower explosion radius.
+			// To fix that, base.Position is changed as it is used as explosion center and ExactPosition is adjusted too - used in some visual/sound effects
+
+			// Because this is an issue fix placed where it fits, simply excluding torpedoes so that their
+			// proximity fuse is not affected
+			if (this is Projectile_ExplosiveShipTorpedo)
+			{
+				base.Impact(hitThing, blockedByShield);
+				return;
+			}
+
+			// for really small explosion radius, just move explosion into hit thing, because otherwise
+			// they are not going to deal damage at all when esploding in adjacent cell
+			if (def.projectile.explosionRadius < 1.1)
+			{
+				if (hitThing != null)
+				{
+					Position = hitThing.Position;
+					base.Impact(hitThing, blockedByShield);
+					return;
+				}
+			}
+
+			// Base game uses 0.2 tile lenth advance along all projectile path,
+			// smaller step when re-checking just last few tiles shuld be fine.
+			const int stepsPerTile = 20;
+			int advanceLength = (int)Math.Ceiling(def.projectile.SpeedTilesPerTick);
+			Vector3 vecAdvance = (destination - origin).normalized/stepsPerTile;
+			Vector3 currentPosition = Position.ToVector3();
+			IntVec3 prevTile = currentPosition.ToIntVec3();
+			// current tile = analyzed, may be occupied. Prev tile = unoccupied, but close proximity, diagonally or cardinally adjacent
+			// tile even before previous is saved for larger explosions. 
+			IntVec3 prevPrevTile = prevTile;
+			ShipMapComp mapComp = base.Map.GetComponent<ShipMapComp>();
+			for (int i = 0; i < advanceLength * stepsPerTile; i++)
+			{
+				IntVec3 newTile = (currentPosition + vecAdvance).ToIntVec3();
+				if (newTile == prevTile)
+				{
+					currentPosition += vecAdvance;
+					continue;
+				}
+				if (mapComp.ShipIndexOnVec(newTile) != -1)
+				{
+					break;
+				}
+				List<Thing> thingList = newTile.GetThingList(base.Map);
+				bool hitBuildingOrVehicle = false;
+				foreach (Thing t in thingList)
+				{
+					// Simplified check here, with main purpose of not allowing pre-mature explosion that damages nothing
+					// if there is something real, rather than sleeping spot etc, that something is ok to be hit.
+					if ((t is Building b && !b.IsClearableFreeBuilding) || t is VehiclePawn)
+					{
+						hitBuildingOrVehicle = true;
+						break;
+					}
+				}
+				if (hitBuildingOrVehicle)
+				{
+					break;
+				}
+				currentPosition += vecAdvance;
+				prevPrevTile = prevTile;
+				prevTile = newTile;
+			}
+			// Overide position with latest position before hitting anythiong in loop above
+			// Should not put new explosion poition into hit ship hull (likely), as it 
+			// afffects efficiency of explosives with large radius. If pushed into hit thing,
+			// they are going to destroy oly that tiler and 2 adjacent, despite much larger actual radius 
+			if (def.projectile.explosionRadius < 2.9)
+			{
+				Position = currentPosition.ToIntVec3();
+			}
+			else
+			{
+				// For larger explosins, advancing to directly adjacent tile may be bad. 
+				// For example, large plasma explosion, when advanced into tile directly adjacent to diagonal wall,
+				// will damage only 2 walls - that's how explosion works
+				// here go 2.9 and larger explosions - large enough radius to fully cover 5x5 square.
+				Position = prevPrevTile;
+			}
+
+			base.Impact(hitThing, blockedByShield);
+		}
 		public override void Tick()
 		{
 			base.Tick();

--- a/Source/1.5/Projectile/Projectile_ExplosiveShipLaser.cs
+++ b/Source/1.5/Projectile/Projectile_ExplosiveShipLaser.cs
@@ -10,28 +10,8 @@ namespace SaveOurShip2
 {
 	class Projectile_ExplosiveShipLaser : Projectile_ExplosiveShip
 	{
-		// Projectile position can be inaccurate by several tiles if it travels several tiles per tick.
-		// To fix that, base.Position is changed as it is used as explosion center and ExactPosition is adjusted too - used in some visual/sound effects
-		// Maybe move this fix up in the class hierarchy after review and testing
-		protected Thing thingHit = null;
-		public override Vector3 ExactPosition
-		{
-			get
-			{
-				if(thingHit != null)
-				{
-					return thingHit.Position.ToVector3();
-				}
-				return base.ExactPosition;
-			}
-		}
 		protected override void Impact(Thing hitThing, bool blockedByShield = false)
 		{
-			thingHit = hitThing;
-			if (thingHit != null)
-			{
-				Position = hitThing.Position;
-			}
 			CompShipHeat heat = base.Launcher.TryGetComp<CompShipHeat>();
 			base.Impact(hitThing);
 			ShipCombatLaserMote obj = (ShipCombatLaserMote)(object)ThingMaker.MakeThing(ResourceBank.ThingDefOf.ShipCombatLaserMote);

--- a/Source/1.5/Projectile/Projectile_ExplosiveShipLaser.cs
+++ b/Source/1.5/Projectile/Projectile_ExplosiveShipLaser.cs
@@ -10,8 +10,25 @@ namespace SaveOurShip2
 {
 	class Projectile_ExplosiveShipLaser : Projectile_ExplosiveShip
 	{
+		// Projectile position can be inaccurate by several tiles if it travels several tiles per tick.
+		// To fix that, base.Position is changed as it is used as explosion center and ExactPosition is adjusted too - used in some visual/sound effects
+		// Maybe move this fix up in the class hierarchy after review and testing
+		protected Thing thingHit = null;
+		public override Vector3 ExactPosition
+		{
+			get
+			{
+				if(thingHit != null)
+				{
+					return thingHit.Position.ToVector3();
+				}
+				return base.ExactPosition;
+			}
+		}
 		protected override void Impact(Thing hitThing, bool blockedByShield = false)
 		{
+			thingHit = hitThing;
+			Position = hitThing.Position;
 			CompShipHeat heat = base.Launcher.TryGetComp<CompShipHeat>();
 			base.Impact(hitThing);
 			ShipCombatLaserMote obj = (ShipCombatLaserMote)(object)ThingMaker.MakeThing(ResourceBank.ThingDefOf.ShipCombatLaserMote);

--- a/Source/1.5/Projectile/Projectile_ExplosiveShipLaser.cs
+++ b/Source/1.5/Projectile/Projectile_ExplosiveShipLaser.cs
@@ -28,7 +28,10 @@ namespace SaveOurShip2
 		protected override void Impact(Thing hitThing, bool blockedByShield = false)
 		{
 			thingHit = hitThing;
-			Position = hitThing.Position;
+			if (thingHit != null)
+			{
+				Position = hitThing.Position;
+			}
 			CompShipHeat heat = base.Launcher.TryGetComp<CompShipHeat>();
 			base.Impact(hitThing);
 			ShipCombatLaserMote obj = (ShipCombatLaserMote)(object)ThingMaker.MakeThing(ResourceBank.ThingDefOf.ShipCombatLaserMote);


### PR DESCRIPTION
harmony patch for red errors when in transit - null map was used there in VehFW
fix for zero damage to hull from shuttle laser in ship battle