### PR TITLE
No auto-zoning wrecks as breathable. That was considered less desireable

### DIFF
--- a/Source/1.5/Comp/ShipMapComp.cs
+++ b/Source/1.5/Comp/ShipMapComp.cs
@@ -105,6 +105,10 @@ namespace SaveOurShip2
 					breathableZone.innerGrid.Clear();
 				foreach(SpaceShipCache ship in shipsOnMap.Values)
                 {
+					if (ship.IsWreck)
+					{
+						continue;
+					}
 					foreach(IntVec3 vec in ship.Area)
                     {
 						if (VecHasLS(vec) && !ShipInteriorMod2.ExposedToOutside(vec.GetRoom(map)))


### PR DESCRIPTION
- if zoned, pawns go to wrecks through open space and get damage ore even die.