### PR TITLE
Code allows moving ships with reactionsless engines to move without RCS

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -1218,6 +1218,7 @@
 					<drawSize>(7,16.5)</drawSize>
 				</graphicData-->
 				<energy>true</energy>
+				<reactionless>true</reactionless>
 				<thrust>1</thrust>
 			</li>
 		</comps>
@@ -1278,6 +1279,7 @@
 					<drawSize>(11,26.5)</drawSize>
 				</graphicData-->
 				<energy>true</energy>
+				<reactionless>true</reactionless>
 				<thrust>4</thrust>
 			</li>
 		</comps>

--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipTechArcho.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipTechArcho.xml
@@ -655,6 +655,7 @@
 			<li Class="SaveOurShip2.CompProps_EngineTrail">
 				<thrust>12</thrust>
 				<fuelUse>1</fuelUse>
+				<reactionless>true</reactionless>
 			</li>
 		</comps>
 		<placeWorkers>


### PR DESCRIPTION
thrusters. Added corresponding property to JT and Antimatter drives so that ship move command works, for example, with captured Amplifier.