### PR TITLE
Added linking between map and world object landed ship for 2 cases:

### DIFF
--- a/Source/1.5/ArrivalAction/AerialVehicleArrivalAction_LoadMapAndDefog.cs
+++ b/Source/1.5/ArrivalAction/AerialVehicleArrivalAction_LoadMapAndDefog.cs
@@ -28,6 +28,7 @@ namespace SaveOurShip2.Vehicles
             LongEventHandler.QueueLongEvent((Action)delegate
             {
                 Map map = GetOrGenerateMapUtility.GetOrGenerateMap(tile, null);
+                MapHelper.TryLinkMapToWorldObject(map, tile);
                 MapLoaded(map);
                 FloodFillerFog.FloodUnfog(CellFinderLoose.TryFindCentralCell(map, 7, 10, (IntVec3 x) => !x.Roofed(map)), map);
                 ExecuteEvents();

--- a/Source/1.5/Building/Building_ShipSensor.cs
+++ b/Source/1.5/Building/Building_ShipSensor.cs
@@ -42,6 +42,10 @@ namespace SaveOurShip2
 						Find.WorldTargeter.BeginTargeting(new Func<GlobalTargetInfo, bool>(ChoseWorldTarget), true, CompCryptoLaunchable.TargeterMouseAttachment);
 					}
 				});
+				if (observedMap != null && observedMap.Destroyed)
+				{
+					observedMap = null;
+				}
 				if (observedMap != null)
 				{
 					giz.Add(new Command_Action

--- a/Source/1.5/Building/Building_ShipSensor.cs
+++ b/Source/1.5/Building/Building_ShipSensor.cs
@@ -72,6 +72,7 @@ namespace SaveOurShip2
 					{
 						GetOrGenerateMapUtility.GetOrGenerateMap(target.WorldObject.Tile, target.WorldObject.def);
 						GetOrGenerateMapUtility.UnfogMapFromEdge(observedMap.Map);
+						MapHelper.TryLinkMapToWorldObject(observedMap.Map, target.Tile);
 					}, "Generating map", false, delegate { });
 					return true;
 				}

--- a/Source/1.5/ShipInteriorMod2.cs
+++ b/Source/1.5/ShipInteriorMod2.cs
@@ -3262,4 +3262,20 @@ namespace SaveOurShip2
 			return sb.ToString();
 		}
 	}
+
+	public class MapHelper
+	{
+		public static void TryLinkMapToWorldObject(Map map, int tile)
+		{
+			// For now, issue was found with Escape Ship map due to that map not being linked to world object
+			// So, fixing onlyy that case for now
+			WorldObject worldObject = Find.WorldObjects.ObjectsAt(tile).Where(t => t is EscapeShip).First();
+			if (worldObject != null && worldObject.Faction != Faction.OfPlayer)
+			{
+				// Link map to Escap ship object sho that it gets "Home" icon and when selected on world map, there is Abadon option 
+				map.info.parent = (MapParent)worldObject;
+				worldObject.SetFaction(Faction.OfPlayer);
+			}
+		}
+	}
 }


### PR DESCRIPTION
1. Map creation on huttle arrival to landed ship.
2. Map creation on observing from orbit.

That map handling fix restores abandon button for landed ship map. Which is available when normal caravan enters the map.