### PR TITLE
Changed conflict area around ship restriction: it now disallows any

### DIFF
--- a/Source/1.5/PlaceWorker/PlaceWorker_MoveShip.cs
+++ b/Source/1.5/PlaceWorker/PlaceWorker_MoveShip.cs
@@ -61,7 +61,7 @@ namespace SaveOurShip2
 						}
 					}
 				}
-				foreach (SketchEntity current in ship.conflictSketch?.Entities) //nothing allowed in this
+				foreach (SketchEntity current in ship.conflictSketch?.Entities) //no buildings allowed in this
 				{
 					IntVec3 vec = loc + current.pos;
 					if (!vec.InBounds(map))
@@ -69,7 +69,7 @@ namespace SaveOurShip2
 						result = false;
 						break;
 					}
-					if (vec.GetThingList(map).Any())
+					if (vec.GetFirstBuilding(map) != null)
 					{
 						result = false;
 						break;


### PR DESCRIPTION
buildings, instead of totally anything.

With previous restriction, ship "body" was alowed to be placed over loose items, while conflict are was not allowed - that caused players confusion.

Intended function for conflict area is to prevent merging ships of different factions, so disallowing any buildings looks like proper restriction for that area.