### PR TITLE
Changed projectile correction with simplified hit detection

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
@@ -1209,7 +1209,7 @@
 		<thingClass>Projectile_Explosive</thingClass>
 		<projectile>
 			<damageDef>ShipLaserSmall</damageDef>
-			<speed>60</speed>
+			<speed>800</speed>
 			<explosionRadius>0</explosionRadius>
 			<flyOverhead>true</flyOverhead>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>

--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
@@ -1209,7 +1209,7 @@
 		<thingClass>Projectile_Explosive</thingClass>
 		<projectile>
 			<damageDef>ShipLaserSmall</damageDef>
-			<speed>800</speed>
+			<speed>60</speed>
 			<explosionRadius>0</explosionRadius>
 			<flyOverhead>true</flyOverhead>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>

--- a/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
+++ b/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
@@ -18,6 +18,12 @@ namespace SaveOurShip2
 			// that affects ship weapon projectiles with high speed, but lower explosion radius.
 			// To fix that, base.Position is changed as it is used as explosion center and ExactPosition is adjusted too - used in some visual/sound effects
 
+			// Only apply fix to ship-to-ship weapons, as simplified hit check is used. Just not change things wthin map for now. 
+			if (hitThing != null && Launcher != null && Launcher.Map == hitThing.Map)
+			{
+				base.Impact(hitThing, blockedByShield);
+				return;
+			}
 			// Because this is an issue fix placed where it fits, simply excluding torpedoes so that their
 			// proximity fuse is not affected
 			if (this is Projectile_ExplosiveShipTorpedo)

--- a/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
+++ b/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
@@ -67,6 +67,16 @@ namespace SaveOurShip2
 				{
 					break;
 				}
+				if (!newTile.InBounds(base.Map, 0))
+				{
+					break;
+				}
+				// Do not advance past destination cell
+				if (currentPosition.ToIntVec3() == DestinationCell)
+				{
+					break;
+				}
+
 				List<Thing> thingList = newTile.GetThingList(base.Map);
 				bool hitBuildingOrVehicle = false;
 				foreach (Thing t in thingList)


### PR DESCRIPTION
 to only apply to ship-to ship (=map-to-other-map) weapons, beause caused issues for shuttle laser firing within map