### PR TITLE
Some kids learning needs don't work in space. So, disable them on space maps.

### DIFF
--- a/1.5/Defs/JobDefs/Jobs_Learning.xml
+++ b/1.5/Defs/JobDefs/Jobs_Learning.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <jobDef>
+    <defName>AdmiringSpace</defName>
+    <driverClass>SaveOurShip2.JobDriver_AdmireSpace</driverClass>
+    <reportString>admiring space.</reportString>
+  </jobDef>
+  
+</Defs>

--- a/1.5/Defs/LearningDesireDefs/LearningDesires.xml
+++ b/1.5/Defs/LearningDesireDefs/LearningDesires.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+  <LearningDesireDef>
+    <defName>AmiringSpace</defName>
+    <label>admiring space</label>
+    <description>Space is so beautiful. Many kids admire it and dream of future life among the stars. Requires some kind of telescope.</description>
+    <iconPath>UI/Icons/Learning/Radiotalking</iconPath>
+    <workerClass>SaveOurShip2.LearningGiver_AdmiringSpace</workerClass>
+    <jobDef>AdmiringSpace</jobDef>
+  </LearningDesireDef>
+</Defs>

--- a/1.5/Defs/LearningDesireDefs/LearningDesires.xml
+++ b/1.5/Defs/LearningDesireDefs/LearningDesires.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
   <LearningDesireDef>
-    <defName>AmiringSpace</defName>
+    <defName>AdmiringSpace</defName>
     <label>admiring space</label>
     <description>Space is so beautiful. Many kids admire it and dream of future life among the stars. Requires some kind of telescope.</description>
     <iconPath>UI/Icons/Learning/Radiotalking</iconPath>

--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4908,6 +4908,27 @@ namespace SaveOurShip2
 		}
     }
 
+	// Biotech - when on space map, disomle kids learning options that don't work
+	[HarmonyPatch(typeof(Pawn_LearningTracker), "AddNewLearningDesire")]
+	public static class ProperLearningNeedsInSpace
+    {
+		public static bool Prefix(Pawn_LearningTracker __instance)
+        {
+			List<LearningDesireDef> learningOptions = DefDatabase<LearningDesireDef>.AllDefsListForReading.Where((LearningDesireDef ld) => !__instance.active.Contains(ld) && ld.Worker.CanGiveDesire).ToList();
+			if (__instance.Pawn.Map != null && __instance.Pawn.Map.IsSpace())
+			{
+				learningOptions = learningOptions.Where((LearningDesireDef ld) => ld.defName != "NatureRunning" && ld.defName != "Skydreaming").ToList();
+			}
+			LearningDesireDef item = learningOptions.RandomElementByWeight((LearningDesireDef ld) => ld.selectionWeight);
+			if (__instance.active.Count >= 2)
+			{
+				__instance.active.RemoveAt(0);
+			}
+			__instance.active.Add(item);
+			return false;
+		}
+    }
+
 	// Biotech - disable "Summon diabolus available" letters for comm consoles on enemy ships
 	[HarmonyPatch(typeof(CompUseEffect_CallBossgroup), "PostSpawnSetup")]
 	public static class DisableMechSpawnAvailableLetter

--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4918,17 +4918,18 @@ namespace SaveOurShip2
 			if (__instance.Pawn.Map != null && __instance.Pawn.Map.IsSpace())
 			{
 				learningOptions = learningOptions.Where((LearningDesireDef ld) => ld.defName != "NatureRunning" && ld.defName != "Skydreaming").ToList();
-				if (__instance.Pawn.Map.listerBuildings.allBuildingsColonist.Any((Building b) => b.def.defName == "Telescope" || b.def.defName == "TelescopeSpace"))
+				if ((__instance.Pawn.Map.listerBuildings.allBuildingsColonist.Any((Building b) => b.def.defName == "Telescope" || b.def.defName == "TelescopeSpace")) &&
+					!__instance.active.Any((LearningDesireDef ld) => ld.defName == "AdmiringSpace"))
 				{
-					learningOptions.Add(DefDatabase<LearningDesireDef>.AllDefsListForReading.First((LearningDesireDef ld) => ld.defName == "AmiringSpace"));
+					learningOptions.Add(DefDatabase<LearningDesireDef>.AllDefsListForReading.First((LearningDesireDef ld) => ld.defName == "AdmiringSpace"));
 				}
 			}
-			LearningDesireDef item = learningOptions.RandomElementByWeight((LearningDesireDef ld) => ld.selectionWeight);
+			LearningDesireDef newDesire = learningOptions.RandomElementByWeight((LearningDesireDef ld) => ld.selectionWeight);
 			if (__instance.active.Count >= 2)
 			{
 				__instance.active.RemoveAt(0);
 			}
-			__instance.active.Add(item);
+			__instance.active.Add(newDesire);
 			return false;
 		}
     }

--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4918,6 +4918,10 @@ namespace SaveOurShip2
 			if (__instance.Pawn.Map != null && __instance.Pawn.Map.IsSpace())
 			{
 				learningOptions = learningOptions.Where((LearningDesireDef ld) => ld.defName != "NatureRunning" && ld.defName != "Skydreaming").ToList();
+				if (__instance.Pawn.Map.listerBuildings.allBuildingsColonist.Any((Building b) => b.def.defName == "Telescope" || b.def.defName == "TelescopeSpace"))
+				{
+					learningOptions.Add(DefDatabase<LearningDesireDef>.AllDefsListForReading.First((LearningDesireDef ld) => ld.defName == "AmiringSpace"));
+				}
 			}
 			LearningDesireDef item = learningOptions.RandomElementByWeight((LearningDesireDef ld) => ld.selectionWeight);
 			if (__instance.active.Count >= 2)

--- a/Source/1.5/Jobs/JobDriver_AdmireSpace.cs
+++ b/Source/1.5/Jobs/JobDriver_AdmireSpace.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Verse;
+using Verse.AI;
+using Verse.Sound;
+using RimWorld;
+
+namespace SaveOurShip2
+{
+	class JobDriver_AdmireSpace : JobDriver
+	{
+		public Building telescope => (Building)base.TargetThingA;
+
+		public override bool TryMakePreToilReservations(bool errorOnFailed)
+		{
+			return pawn.Reserve(base.TargetA, job, 1, -1, null, errorOnFailed);
+		}
+
+		protected override IEnumerable<Toil> MakeNewToils()
+		{
+			this.FailOnDespawnedOrNull(TargetIndex.A);
+			this.FailOnSomeonePhysicallyInteracting(TargetIndex.A);
+			this.FailOnChildLearningConditions();
+			this.FailOn(() => telescope.IsForbidden(pawn));
+			yield return Toils_Goto.GotoCell(TargetIndex.A, PathEndMode.InteractionCell).FailOn(() => telescope.IsForbidden(pawn));
+			Toil toil = ToilMaker.MakeToil("MakeNewToils");
+			toil.tickAction = delegate
+			{
+				pawn.rotationTracker.FaceTarget(base.TargetA);
+				LearningUtility.LearningTickCheckEnd(pawn);
+			};
+			// toil.WithEffect(EffecterDefOf.Radiotalking, TargetIndex.A);
+			toil.handlingFacing = true;
+			toil.defaultCompleteMode = ToilCompleteMode.Never;
+			yield return toil;
+		}
+	}
+}

--- a/Source/1.5/Jobs/LearningGiver_AdmiringSpace.cs
+++ b/Source/1.5/Jobs/LearningGiver_AdmiringSpace.cs
@@ -1,0 +1,61 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Verse;
+using Verse.AI;
+
+namespace SaveOurShip2
+{
+	public class LearningGiver_AdmiringSpace : LearningGiver
+	{
+		// Cannot work properly because context is not passed to this function.
+		// So will just return false, but this desire will be added manually in harmony patch?
+		public override bool CanGiveDesire
+		{
+			get
+			{
+				return false;
+			}
+		}
+
+		private bool TryFindTelescope(Pawn pawn, out Thing telescopeResult)
+		{
+			Thing spaceTelecope = null;
+			Thing telecope = null;
+			if (pawn != null)
+			{
+				spaceTelecope = GenClosest.ClosestThingReachable(pawn.Position, pawn.Map, ThingRequest.ForDef(ThingDef.Named("TelescopeSpace")), PathEndMode.InteractionCell, TraverseParms.For(pawn), 9999f, (Thing t) => t is Building b && pawn.CanReserve(b) && !b.IsForbidden(pawn));
+				telecope = GenClosest.ClosestThingReachable(pawn.Position, pawn.Map, ThingRequest.ForDef(ThingDef.Named("Telescope")), PathEndMode.InteractionCell, TraverseParms.For(pawn), 9999f, (Thing t) => t is Building b && pawn.CanReserve(b) && !b.IsForbidden(pawn));
+			}
+			if (spaceTelecope != null)
+			{
+				telescopeResult = spaceTelecope;
+			}
+			else
+			{
+				telescopeResult = telecope;
+			}
+			return telescopeResult != null;
+		}
+
+		public override bool CanDo(Pawn pawn)
+		{
+			if (!base.CanDo(pawn))
+			{
+				return false;
+			}
+			return TryFindTelescope(pawn, out var telecope);
+		}
+
+		public override Job TryGiveJob(Pawn pawn)
+		{
+			if (!TryFindTelescope(pawn, out var telesope))
+			{
+				return null;
+			}
+			return JobMaker.MakeJob(def.jobDef, telesope);
+		}
+	}
+}

--- a/Source/1.5/RimworldMod.csproj
+++ b/Source/1.5/RimworldMod.csproj
@@ -262,6 +262,7 @@
     <Compile Include="Graphic\Graphic_SingleOnOffEmpty.cs" />
     <Compile Include="HarmonyPatches.cs" />
     <Compile Include="HediffPawnIsHologram.cs" />
+    <Compile Include="Jobs\JobDriver_AdmireSpace.cs" />
     <Compile Include="Jobs\JobDriver_BreachAirlock.cs" />
     <Compile Include="Jobs\JobDriver_CarryToCryptonest.cs" />
     <Compile Include="Jobs\JobDriver_DefendBreacher.cs" />
@@ -291,6 +292,7 @@
     <Compile Include="Jobs\JobGiver_LoadTorpedoes.cs" />
     <Compile Include="Jobs\JobGiver_ManShipBridge.cs" />
     <Compile Include="Jobs\JobGiver_RepairShields.cs" />
+    <Compile Include="Jobs\LearningGiver_AdmiringSpace.cs" />
     <Compile Include="Jobs\LordJob_AssaultShip.cs" />
     <Compile Include="Jobs\LordJob_DefendShip.cs" />
     <Compile Include="Jobs\LordToil_AssaultShip.cs" />


### PR DESCRIPTION
This is the least that could be done to allow players raise kids on spaceships investing time in their learning and get a deserved reward for that. Ideally, might have new learning types in space.