### PR TITLE
LungFixForUnstable

### DIFF
--- a/1.5/Defs/HediffDefs/Hediffs_BodyParts_Archotech.xml
+++ b/1.5/Defs/HediffDefs/Hediffs_BodyParts_Archotech.xml
@@ -292,6 +292,7 @@
 			<li>
 				<statOffsets>
 					<HypoxiaResistance>1</HypoxiaResistance>
+					<ToxicEnvironmentResistance MayRequire="Ludeon.RimWorld.Biotech">0.5</ToxicEnvironmentResistance>
 				</statOffsets>
 			</li>
 		</stages>


### PR DESCRIPTION
Updates Archotech lungs to provide 50 toxic environment resistance each, so that 2 of them provide immunity to things such as lung rot. Has MayRequire biotech so that there is no compatibility issues with not having the DLC.