### PR TITLE
RewardEmpireDestroyerFixForUnstable

### DIFF
--- a/1.5/Defs/Misc/ShipDefs/Special/RewardEmpireDestroyer.xml
+++ b/1.5/Defs/Misc/ShipDefs/Special/RewardEmpireDestroyer.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 	<SaveOurShip2.ShipDef>
 		<defName>RewardEmpireDestroyer</defName>
@@ -8,142 +8,146 @@
 		<sizeX>108</sizeX>
 		<sizeZ>52</sizeZ>
 		<label>Imperial Longinus class destroyer</label>
-		<combatPoints>994</combatPoints>
-		<neverRandom>True</neverRandom>
+		<combatPoints>1014</combatPoints>
+		<rarityLevel>0</rarityLevel>
+		<neverRandom>False</neverRandom>
+		<neverAttacks>False</neverAttacks>
+		<neverWreck>False</neverWreck>
+		<startingShip>False</startingShip>
+		<startingDungeon>False</startingDungeon>
+		<spaceSite>False</spaceSite>
+		<tradeShip>False</tradeShip>
+		<navyExclusive>False</navyExclusive>
+		<customPaintjob>False</customPaintjob>
 		<neverFleet>True</neverFleet>
 		<core>
-			<shapeOrDef>ShipPilotSeatMini</shapeOrDef>
-			<x>49</x>
-			<z>28</z>
-			<rot>3</rot>
+			<shapeOrDef>Ship_DroneCore</shapeOrDef>
+			<x>38</x>
+			<z>26</z>
 		</core>
 		<symbolTable>
 			<li>
 				<key>?</key>
 				<value>
-					<shapeOrDef>Ship_DroneCore</shapeOrDef>
+					<shapeOrDef>MealSimple</shapeOrDef>
 				</value>
 			</li>
 			<li>
 				<key>@</key>
 				<value>
-					<shapeOrDef>ShipHullTile</shapeOrDef>
+					<shapeOrDef>MealFine</shapeOrDef>
 				</value>
 			</li>
 			<li>
 				<key>A</key>
+				<value>
+					<shapeOrDef>MealSurvivalPack</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>B</key>
+				<value>
+					<shapeOrDef>HullFoam</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>C</key>
+				<value>
+					<shapeOrDef>ShuttleFuelPods</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>D</key>
+				<value>
+					<shapeOrDef>Silver</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>E</key>
+				<value>
+					<shapeOrDef>Apparel_SpaceSuitBody</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>F</key>
+				<value>
+					<shapeOrDef>Apparel_SpaceSuitHelmet</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>G</key>
+				<value>
+					<shapeOrDef>SoS2_Shuttle</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>H</key>
+				<value>
+					<shapeOrDef>ShipTorpedo_EMP</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>I</key>
+				<value>
+					<shapeOrDef>ComponentIndustrial</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>J</key>
+				<value>
+					<shapeOrDef>ShipTorpedo_HighExplosive</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>K</key>
+				<value>
+					<shapeOrDef>ShipTorpedo_Antimatter</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>L</key>
+				<value>
+					<shapeOrDef>MedicineIndustrial</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>M</key>
+				<value>
+					<shapeOrDef>ShipHullTile</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>N</key>
 				<value>
 					<shapeOrDef>Ship_Beam</shapeOrDef>
 					<colorDef>Structure_Red</colorDef>
 				</value>
 			</li>
 			<li>
-				<key>B</key>
+				<key>O</key>
 				<value>
 					<shapeOrDef>ShipInside_PassiveVent</shapeOrDef>
 					<colorDef>Structure_Red</colorDef>
 				</value>
 			</li>
 			<li>
-				<key>C</key>
-				<value>
-					<shapeOrDef>Ship_SensorClusterAdv</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>D</key>
+				<key>P</key>
 				<value>
 					<shapeOrDef>ShipAirlock</shapeOrDef>
 					<colorDef>Structure_Red</colorDef>
 				</value>
 			</li>
 			<li>
-				<key>E</key>
-				<value>
-					<shapeOrDef>Ship_CryptosleepCasket</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>F</key>
-				<value>
-					<shapeOrDef>MealSimple</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>G</key>
-				<value>
-					<shapeOrDef>Shelf</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>H</key>
-				<value>
-					<shapeOrDef>MealFine</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>I</key>
-				<value>
-					<shapeOrDef>FlatscreenTelevision</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>J</key>
+				<key>Q</key>
 				<value>
 					<shapeOrDef>Ship_Beam_Unpowered</shapeOrDef>
 					<colorDef>Structure_Red</colorDef>
 				</value>
 			</li>
 			<li>
-				<key>K</key>
-				<value>
-					<shapeOrDef>Ship_Corner_OneTwoFlip</shapeOrDef>
-					<colorDef>Structure_Red</colorDef>
-				</value>
-			</li>
-			<li>
-				<key>L</key>
-				<value>
-					<shapeOrDef>ShipTurret_Laser</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>M</key>
-				<value>
-					<shapeOrDef>MealSurvivalPack</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>N</key>
-				<value>
-					<shapeOrDef>Ship_LifeSupport</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>O</key>
-				<value>
-					<shapeOrDef>ShipCombatShieldGenerator</shapeOrDef>
-					<radius>40</radius>
-				</value>
-			</li>
-			<li>
-				<key>P</key>
-				<value>
-					<shapeOrDef>Turret_MiniTurret</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>Q</key>
-				<value>
-					<shapeOrDef>CommsConsole</shapeOrDef>
-				</value>
-			</li>
-			<li>
 				<key>R</key>
 				<value>
-					<shapeOrDef>Table1x2c</shapeOrDef>
+					<shapeOrDef>Turret_MiniTurret</shapeOrDef>
 					<stuff>Steel</stuff>
 				</value>
 			</li>
@@ -157,450 +161,480 @@
 			<li>
 				<key>T</key>
 				<value>
-					<shapeOrDef>ShipSalvageBay</shapeOrDef>
+					<shapeOrDef>ShipHeatConduit</shapeOrDef>
 				</value>
 			</li>
 			<li>
 				<key>U</key>
 				<value>
-					<shapeOrDef>HullFoam</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>V</key>
-				<value>
-					<shapeOrDef>HullFoamDistributor</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>W</key>
-				<value>
-					<shapeOrDef>ElectricStove</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>X</key>
-				<value>
-					<shapeOrDef>ShipHeatConduit</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>Y</key>
-				<value>
-					<shapeOrDef>Ship_Reactor</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>Z</key>
-				<value>
-					<shapeOrDef>Ship_Engine_Large</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>[</key>
-				<value>
-					<shapeOrDef>ShuttleFuelPods</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>\</key>
-				<value>
-					<shapeOrDef>ShipCapacitorSmall</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>]</key>
-				<value>
 					<shapeOrDef>PowerConduit</shapeOrDef>
 				</value>
 			</li>
 			<li>
-				<key>^</key>
-				<value>
-					<shapeOrDef>Ship_Corner_OneTwo</shapeOrDef>
-					<colorDef>Structure_Red</colorDef>
-				</value>
-			</li>
-			<li>
-				<key>_</key>
-				<value>
-					<shapeOrDef>ShipHeatManifold</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>`</key>
-				<value>
-					<shapeOrDef>ShipTurret_Kinetic</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>a</key>
-				<value>
-					<shapeOrDef>Ship_Corner_OneThreeFlip</shapeOrDef>
-					<colorDef>Structure_Red</colorDef>
-				</value>
-			</li>
-			<li>
-				<key>b</key>
+				<key>V</key>
 				<value>
 					<shapeOrDef>Ship_Thruster</shapeOrDef>
 					<colorDef>Structure_GrayLight</colorDef>
 				</value>
 			</li>
 			<li>
-				<key>c</key>
-				<value>
-					<shapeOrDef>ShipPurgePort</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>d</key>
-				<value>
-					<shapeOrDef>Silver</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>e</key>
-				<value>
-					<shapeOrDef>Ship_Corner_OneThree</shapeOrDef>
-					<colorDef>Structure_Red</colorDef>
-				</value>
-			</li>
-			<li>
-				<key>f</key>
+				<key>W</key>
 				<value>
 					<shapeOrDef>Ship_Corner_OneOneFlip</shapeOrDef>
 					<colorDef>Structure_Red</colorDef>
 				</value>
 			</li>
 			<li>
-				<key>g</key>
-				<value>
-					<shapeOrDef>ShipHeatsinkLarge</shapeOrDef>
-					<colorDef>Structure_GrayLight</colorDef>
-				</value>
-			</li>
-			<li>
-				<key>h</key>
-				<value>
-					<shapeOrDef>HydroponicsBasin</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>i</key>
-				<value>
-					<shapeOrDef>Dresser</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>j</key>
-				<value>
-					<shapeOrDef>Bed</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>k</key>
-				<value>
-					<shapeOrDef>EndTable</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>l</key>
-				<value>
-					<shapeOrDef>DoubleBed</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>m</key>
+				<key>X</key>
 				<value>
 					<shapeOrDef>FirefoamPopper</shapeOrDef>
 				</value>
 			</li>
 			<li>
-				<key>n</key>
-				<value>
-					<shapeOrDef>ShipConsoleScience</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>o</key>
+				<key>Y</key>
 				<value>
 					<shapeOrDef>ChessTable</shapeOrDef>
 					<stuff>Steel</stuff>
 				</value>
 			</li>
 			<li>
-				<key>p</key>
-				<value>
-					<shapeOrDef>Table2x2c</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>q</key>
-				<value>
-					<shapeOrDef>HospitalBed</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>r</key>
-				<value>
-					<shapeOrDef>PokerTable</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>s</key>
+				<key>Z</key>
 				<value>
 					<shapeOrDef>Ship_Corner_OneOne</shapeOrDef>
 					<colorDef>Structure_Red</colorDef>
 				</value>
 			</li>
 			<li>
-				<key>t</key>
-				<value>
-					<shapeOrDef>Apparel_SpaceSuitBody</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>u</key>
-				<value>
-					<shapeOrDef>ElectricTailoringBench</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key>v</key>
-				<value>
-					<shapeOrDef>TableMachining</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>w</key>
-				<value>
-					<shapeOrDef>FabricationBench</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>x</key>
+				<key>[</key>
 				<value>
 					<shapeOrDef>Stool</shapeOrDef>
 					<stuff>Steel</stuff>
 				</value>
 			</li>
 			<li>
-				<key>y</key>
+				<key>\</key>
 				<value>
 					<shapeOrDef>OrbitalTradeBeacon</shapeOrDef>
 				</value>
 			</li>
 			<li>
-				<key>z</key>
-				<value>
-					<shapeOrDef>ElectricSmelter</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>{</key>
-				<value>
-					<shapeOrDef>Apparel_SpaceSuitHelmet</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key>}</key>
-				<value>
-					<shapeOrDef>Armchair</shapeOrDef>
-					<stuff>Cloth</stuff>
-				</value>
-			</li>
-			<li>
-				<key>~</key>
+				<key>]</key>
 				<value>
 					<shapeOrDef>ShipLandingBeacon</shapeOrDef>
 				</value>
 			</li>
 			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipShuttleBay</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>SoS2_Shuttle</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipTorpedoTwo</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipTorpedo_EMP</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ComponentIndustrial</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipCapacitor</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipSpinalAmplifier</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipSpinalEmitter</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipTorpedo_HighExplosive</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipSpinalBarrelLaser</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipTorpedo_Antimatter</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
+				<key>^</key>
 				<value>
 					<shapeOrDef>StandingLamp</shapeOrDef>
 				</value>
 			</li>
 			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>MegascreenTelevision</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>Drape</shapeOrDef>
-					<stuff>Leather_Dog</stuff>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>Column</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>ShipConsoleTactical</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>Throne</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key></key>
+				<key>_</key>
 				<value>
 					<shapeOrDef>ShipAirlockBeam</shapeOrDef>
 					<colorDef>Structure_Red</colorDef>
 				</value>
 			</li>
 			<li>
-				<key></key>
+				<key>`</key>
+				<value>
+					<shapeOrDef>EndTable</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key>a</key>
 				<value>
 					<shapeOrDef>Barricade</shapeOrDef>
 					<stuff>Steel</stuff>
 				</value>
 			</li>
 			<li>
-				<key></key>
+				<key>b</key>
 				<value>
 					<shapeOrDef>WallLamp</shapeOrDef>
 				</value>
 			</li>
 			<li>
-				<key></key>
+				<key>c</key>
 				<value>
 					<shapeOrDef>WallSunLampSoS</shapeOrDef>
 				</value>
 			</li>
 			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>Bookcase</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key></key>
+				<key>d</key>
 				<value>
 					<shapeOrDef>ShelfSmall</shapeOrDef>
 					<stuff>Steel</stuff>
 				</value>
 			</li>
 			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>BookcaseSmall</shapeOrDef>
-					<stuff>Steel</stuff>
-				</value>
-			</li>
-			<li>
-				<key></key>
-				<value>
-					<shapeOrDef>MedicineIndustrial</shapeOrDef>
-				</value>
-			</li>
-			<li>
-				<key></key>
+				<key>e</key>
 				<value>
 					<shapeOrDef>VitalsMonitor</shapeOrDef>
 				</value>
 			</li>
 			<li>
+				<key>f</key>
+				<value>
+					<shapeOrDef>Armchair</shapeOrDef>
+					<stuff>Leather_Dog</stuff>
+				</value>
+			</li>
+			<li>
+				<key>g</key>
+				<value>
+					<shapeOrDef>Column</shapeOrDef>
+					<stuff>WoodLog</stuff>
+				</value>
+			</li>
+			<li>
+				<key>h</key>
+				<value>
+					<shapeOrDef>Brazier</shapeOrDef>
+					<stuff>BlocksSandstone</stuff>
+				</value>
+			</li>
+			<li>
+				<key>i</key>
+				<value>
+					<shapeOrDef>Ship_CryptosleepCasket</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>j</key>
+				<value>
+					<shapeOrDef>Shelf</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key>k</key>
+				<value>
+					<shapeOrDef>FlatscreenTelevision</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>l</key>
+				<value>
+					<shapeOrDef>Ship_Corner_OneTwoFlip</shapeOrDef>
+					<colorDef>Structure_Red</colorDef>
+				</value>
+			</li>
+			<li>
+				<key>m</key>
+				<value>
+					<shapeOrDef>Table1x2c</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key>n</key>
+				<value>
+					<shapeOrDef>ShipCapacitorSmall</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>o</key>
+				<value>
+					<shapeOrDef>Ship_Corner_OneTwo</shapeOrDef>
+					<colorDef>Structure_Red</colorDef>
+				</value>
+			</li>
+			<li>
+				<key>p</key>
+				<value>
+					<shapeOrDef>HospitalBed</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key>q</key>
+				<value>
+					<shapeOrDef>Bed</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key>r</key>
+				<value>
+					<shapeOrDef>Bookcase</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key>s</key>
+				<value>
+					<shapeOrDef>Drape</shapeOrDef>
+					<stuff>Leather_Dog</stuff>
+				</value>
+			</li>
+			<li>
+				<key>t</key>
+				<value>
+					<shapeOrDef>ShipTurret_Laser</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>u</key>
+				<value>
+					<shapeOrDef>ShipHeatManifold</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>v</key>
+				<value>
+					<shapeOrDef>ShipTurret_Kinetic</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>w</key>
+				<value>
+					<shapeOrDef>ShipPurgePort</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>x</key>
+				<value>
+					<shapeOrDef>Table2x2c</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key>y</key>
+				<value>
+					<shapeOrDef>PokerTable</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key>z</key>
+				<value>
+					<shapeOrDef>ElectricStove</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key>{</key>
+				<value>
+					<shapeOrDef>Ship_Corner_OneThreeFlip</shapeOrDef>
+					<colorDef>Structure_Red</colorDef>
+				</value>
+			</li>
+			<li>
+				<key>}</key>
+				<value>
+					<shapeOrDef>Ship_Corner_OneThree</shapeOrDef>
+					<colorDef>Structure_Red</colorDef>
+				</value>
+			</li>
+			<li>
+				<key>~</key>
+				<value>
+					<shapeOrDef>ElectricTailoringBench</shapeOrDef>
+					<stuff>Steel</stuff>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>TableMachining</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ElectricSmelter</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>MegascreenTelevision</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipConsoleTactical</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipPilotSeatMini</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipConsoleScience</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>CommsConsole</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>GrandThrone</shapeOrDef>
+					<stuff>BlocksSandstone</stuff>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>HydroponicsBasin</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>Ship_SensorClusterAdv</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>Ship_LifeSupport</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipCombatShieldGenerator</shapeOrDef>
+					<radius>40</radius>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>HullFoamDistributor</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>Piano</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipSpinalAmplifier</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>FabricationBench</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipHeatsinkLarge</shapeOrDef>
+					<colorDef>Structure_GrayLight</colorDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipCapacitor</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipSpinalEmitter</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipSpinalBarrelLaser</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipTorpedoTwo</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipSalvageBay</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>Ship_Reactor</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>Ship_Engine_Large</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>ShipShuttleBay</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>RoyalBed</shapeOrDef>
+					<stuff>BlocksSandstone</stuff>
+				</value>
+			</li>
+			<li>
 				<key></key>
 				<value>
-					<shapeOrDef>MetalTile</shapeOrDef>
+					<shapeOrDef>Dresser</shapeOrDef>
+					<stuff>WoodLog</stuff>
 				</value>
 			</li>
 			<li>
 				<key></key>
 				<value>
+					<shapeOrDef>EndTable</shapeOrDef>
+					<stuff>WoodLog</stuff>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>SculptureLarge</shapeOrDef>
+					<stuff>BlocksSandstone</stuff>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>MetalTile</shapeOrDef>
+				</value>
+			</li>
+			<li>
+				<key></key>
+				<value>
 					<shapeOrDef>SterileTile</shapeOrDef>
 				</value>
 			</li>
+			<li>
+				<key></key>
+				<value>
+					<shapeOrDef>CarpetFineOrangePastel</shapeOrDef>
+				</value>
+			</li>
 		</symbolTable>
-		<bigString>38,26,0,?|37,25,0,@|37,26,0,@|37,27,0,@|38,25,0,@|38,26,0,@|38,27,0,@|39,25,0,@|39,26,0,@|39,27,0,@|37,24,0,@|37,24,0,A|36,24,0,A|35,24,0,A|34,24,0,A|33,24,2,B|32,24,0,A|32,25,0,@|32,26,0,@|34,26,0,C|33,26,0,@|34,26,0,@|35,26,0,@|35,27,0,@|35,28,0,A|36,28,0,A|36,29,1,D|37,29,0,@|38,29,0,@|39,29,0,@|40,29,0,@|40,30,2,E|40,28,0,@|40,28,0,A|41,28,0,@|41,28,0,A|41,27,0,@|41,27,0,A|41,26,0,@|41,26,1,D|41,25,0,@|41,25,0,A|41,24,0,@|41,24,0,A|41,23,0,@|41,23,0,A|41,22,0,@|41,22,0,A|41,21,0,@|41,21,0,A|41,20,0,@|41,19,0,@|41,18,0,A|41,17,2,F|41,17,0,@|41,17,1,G|41,16,2,H|41,16,0,@|41,15,0,@|41,14,0,@|41,13,0,@|41,13,1,I|41,12,0,@|41,11,2,F|41,11,0,@|41,11,1,G|41,10,0,@|41,9,0,@|41,8,0,A|41,7,0,J|32,23,0,@|31,23,0,@|31,22,0,@|31,21,0,@|31,21,0,A|31,20,0,@|31,20,0,A|31,19,0,@|31,19,0,A|31,18,0,A|31,17,0,A|31,16,3,K|32,22,0,@|33,22,0,@|34,22,0,@|34,21,0,@|34,21,0,A|34,20,0,@|34,19,0,@|34,18,0,B|33,21,0,@|33,21,0,D|33,25,0,@|33,23,0,@|34,25,0,@|34,23,0,@|35,25,0,@|35,23,0,@|36,23,1,D|36,22,0,A|37,21,0,E|37,22,0,@|38,22,0,@|38,23,0,@|39,23,0,@|39,22,0,@|39,21,0,@|39,20,0,@|38,20,0,@|37,19,0,E|37,20,0,@|36,20,0,A|36,19,0,A|36,18,0,A|37,18,0,A|38,18,0,D|38,17,0,@|38,16,0,@|38,15,0,@|38,14,0,@|38,13,0,@|38,12,0,@|38,11,0,@|38,11,0,A|38,10,2,L|38,10,0,@|38,9,0,@|38,8,0,A|38,7,0,J|37,17,2,M|37,17,0,@|37,17,1,G|36,17,0,A|36,16,0,A|35,16,0,J|35,15,0,J|35,14,0,J|36,14,0,A|36,13,0,A|36,12,0,A|36,11,0,A|36,10,0,A|36,9,0,A|36,8,0,A|36,7,0,J|35,13,0,J|36,15,0,A|37,19,0,@|38,19,0,@|39,19,0,@|38,21,0,@|37,21,0,@|36,21,0,A|37,23,0,@|38,24,0,@|38,24,0,A|39,24,0,@|39,24,0,A|40,25,0,@|40,26,0,@|40,27,0,@|39,28,0,@|39,28,0,A|38,28,0,@|38,28,0,A|37,28,0,@|37,28,0,A|36,27,0,A|36,26,0,A|36,25,0,A|31,24,0,D|30,24,0,A|29,24,0,A|28,24,0,A|27,24,0,A|26,24,0,A|25,24,0,A|24,24,0,D|23,24,0,A|22,24,0,A|21,24,0,A|20,24,0,A|19,24,3,B|19,23,1,D|19,22,0,A|19,21,0,A|19,20,0,A|19,19,0,A|19,18,0,A|19,17,0,A|19,16,0,A|19,15,0,A|19,14,0,A|19,13,0,A|19,12,0,A|19,11,0,A|19,10,3,K|21,26,0,N|20,25,0,@|20,26,0,@|20,27,0,@|21,27,0,@|22,27,0,@|22,26,0,@|23,26,0,@|24,26,0,@|25,25,3,G|25,26,0,@|26,26,0,@|26,26,0,A|28,26,0,O|27,26,0,@|28,26,0,@|29,26,0,@|30,27,0,@|31,27,0,@|31,28,0,D|32,28,0,A|33,28,0,B|33,29,0,@|34,29,0,@|34,30,0,@|35,30,0,@|35,30,0,P|35,31,0,@|35,31,0,A|36,31,0,A|37,30,0,E|37,31,0,@|38,31,0,@|39,31,0,@|40,31,0,@|41,31,0,@|41,31,0,A|41,30,0,@|41,30,0,A|42,30,0,@|42,29,0,@|43,29,0,@|43,28,0,@|43,27,0,@|43,26,0,@|43,25,0,@|43,24,0,@|43,23,0,@|44,22,0,Q|43,22,0,@|43,21,0,@|43,21,0,A|43,20,0,@|43,19,0,@|43,18,0,A|43,17,0,@|43,16,0,@|43,15,0,@|43,14,0,@|43,13,0,@|43,12,0,@|43,11,1,R|43,11,0,@|43,10,0,@|43,10,0,S|43,9,0,@|43,8,0,A|43,7,0,J|21,26,0,@|20,23,0,@|21,25,0,@|21,23,0,@|21,22,0,@|22,22,0,@|23,22,0,@|24,22,0,@|25,22,0,@|23,19,0,T|25,21,0,@|25,20,0,@|25,19,0,@|25,18,0,@|25,17,0,@|25,16,0,@|25,15,0,A|25,14,0,J|25,13,3,K|24,21,0,@|23,21,0,@|23,20,0,@|22,20,0,@|21,20,0,@|21,19,0,@|21,18,0,@|21,17,0,@|21,16,0,@|21,15,0,@|21,14,0,@|21,13,0,A|21,12,0,J|21,11,3,K|22,19,0,@|23,19,0,@|23,18,0,@|23,17,0,@|23,16,0,@|23,15,0,@|23,14,0,A|23,13,0,J|23,12,3,K|22,21,0,@|21,21,0,@|22,25,0,@|22,23,0,@|23,25,0,@|23,23,0,@|24,25,0,@|24,23,0,@|25,25,0,@|25,23,0,@|26,25,0,@|26,25,0,A|26,23,0,@|27,25,0,@|27,23,0,@|27,22,0,@|28,21,3,G|28,22,0,U|28,22,0,@|29,22,0,@|29,22,3,B|29,21,0,@|29,21,0,A|29,19,0,V|29,20,0,@|28,20,0,@|27,20,0,@|27,19,0,@|27,18,0,@|28,18,0,@|29,18,0,@|29,17,0,A|29,16,0,J|28,16,0,A|27,16,0,A|27,15,0,J|27,14,3,K|29,15,3,K|28,17,0,A|27,17,0,@|28,19,0,@|29,19,0,@|28,21,0,U|28,21,0,@|27,21,0,@|28,25,0,@|28,23,0,@|29,25,0,@|29,23,0,@|29,23,1,D|30,25,0,@|31,25,0,@|32,27,0,@|31,26,0,@|33,27,0,@|34,27,0,@|35,29,0,@|34,28,0,A|36,30,0,A|37,30,0,@|38,30,0,@|39,30,0,@|41,29,0,@|41,29,0,A|40,30,0,@|42,28,0,@|42,27,0,@|42,26,0,@|42,25,0,@|42,24,0,@|40,24,0,@|40,24,0,A|42,23,0,@|40,23,0,@|40,23,2,E|42,22,0,@|40,22,0,@|42,21,0,@|42,21,0,A|40,21,0,@|42,20,0,@|40,20,0,@|42,19,0,@|40,19,0,@|42,18,0,D|40,18,0,A|42,17,0,@|40,17,0,@|40,17,0,A|42,16,0,@|40,16,0,@|40,16,0,A|42,15,0,@|40,15,0,@|40,15,1,D|42,14,0,@|40,14,0,@|40,14,0,A|42,13,0,@|40,13,0,@|40,13,0,A|42,12,0,@|40,12,0,@|40,12,0,A|42,11,0,@|40,11,0,@|40,11,0,A|42,10,0,@|40,10,0,@|40,10,0,A|42,9,0,@|40,9,0,@|40,9,1,D|42,8,0,A|40,8,0,A|42,7,0,J|40,7,0,J|30,23,0,@|30,22,0,@|32,21,0,@|32,21,0,A|30,21,0,@|30,21,0,A|32,20,0,@|30,20,0,@|32,19,0,@|30,19,0,@|32,18,0,A|30,18,0,@|30,17,0,A|35,22,0,@|35,22,0,P|35,21,0,@|35,21,0,A|35,19,3,G|35,20,0,@|33,20,0,@|35,19,0,@|33,19,0,@|35,18,0,A|35,17,0,J|39,18,2,B|39,17,0,@|39,16,0,@|37,16,2,M|37,16,0,@|39,15,0,@|37,15,2,H|37,15,0,@|37,15,1,G|39,13,1,W|39,14,0,@|37,14,0,@|39,13,0,@|37,13,0,@|39,12,0,@|37,12,0,@|39,11,0,@|39,11,0,A|37,11,0,@|37,11,0,A|39,10,0,@|37,10,0,@|39,9,0,@|37,9,0,@|39,8,0,A|37,8,0,A|39,7,0,J|37,7,0,J|35,12,0,J|35,11,0,J|35,10,0,J|35,9,0,J|35,8,0,J|35,7,0,J|19,25,0,A|18,25,0,@|18,25,0,X|17,25,0,@|17,25,0,X|14,26,0,Y|16,25,0,@|15,25,0,@|14,25,0,@|13,25,0,@|12,25,0,@|11,25,0,A|10,25,0,@|9,25,0,@|8,25,0,A|5,23,1,Z|8,23,1,D|9,23,0,@|10,23,0,[|10,23,0,@|10,23,3,G|11,23,3,B|13,23,3,\|12,23,0,@|13,23,0,@|14,23,0,@|15,23,0,@|16,23,2,G|16,23,0,[|16,23,0,@|17,23,0,@|17,22,0,@|17,21,0,@|15,21,0,G|16,21,0,@|15,21,0,[|15,21,0,@|14,21,0,@|13,21,0,@|13,21,3,\|12,21,0,@|11,21,0,A|10,21,0,[|10,21,0,@|10,20,3,G|9,21,0,@|8,21,0,A|5,18,1,Z|8,19,0,A|9,19,0,@|10,19,0,[|10,19,0,@|10,18,3,G|11,19,0,A|14,18,0,Y|12,19,0,@|13,19,0,@|14,19,0,@|15,19,0,@|16,19,0,@|17,19,0,@|17,19,0,]|17,18,0,@|17,17,0,@|17,17,0,X|16,17,0,@|15,17,0,@|14,17,0,@|13,17,0,@|12,17,0,@|11,17,0,A|10,17,0,A|9,17,0,A|8,17,0,A|3,14,0,^|4,15,0,A|5,15,0,A|6,15,0,A|7,15,0,A|8,15,0,A|9,15,0,@|9,15,0,_|10,15,0,@|11,15,2,B|12,15,0,A|13,15,0,A|14,15,0,A|15,15,0,A|16,15,0,A|17,15,0,D|17,14,0,@|18,13,2,L|17,13,0,@|16,13,0,@|15,13,0,@|14,13,0,@|13,13,0,@|12,13,0,@|11,13,0,@|10,13,0,@|9,13,0,@|8,13,0,@|7,13,0,@|6,13,0,@|6,14,2,`|5,13,0,@|4,13,0,A|3,13,0,A|1,13,1,a|0,12,0,J|0,10,0,a|1,11,0,J|2,11,0,J|3,11,0,A|4,11,0,@|5,12,2,L|5,11,0,@|6,11,0,@|7,11,3,\|7,11,0,@|8,11,0,@|8,11,0,_|9,11,0,@|10,11,0,@|10,11,0,_|10,10,0,A|10,9,0,J|9,10,0,A|8,10,0,A|8,9,0,J|7,9,0,J|6,9,0,J|7,10,0,A|6,10,0,A|5,10,0,A|4,10,0,A|4,9,0,b|3,9,0,J|2,9,0,b|1,9,0,J|3,10,0,A|2,10,0,A|1,10,0,J|1,12,0,J|2,12,0,J|3,12,0,A|4,12,0,@|5,12,0,@|6,12,0,@|7,12,0,@|8,12,0,@|9,12,0,@|10,12,0,@|11,12,0,@|12,11,0,_|12,12,0,@|12,11,0,@|13,11,0,@|14,11,0,@|14,11,0,c|15,11,0,@|16,11,0,@|16,12,2,\|17,11,0,A|17,10,0,A|17,9,3,K|15,9,0,J|14,9,0,J|13,9,0,J|12,9,0,J|16,10,0,A|15,10,0,A|14,10,0,A|13,10,0,A|12,10,0,A|13,12,0,@|14,12,0,@|15,12,0,@|16,12,0,@|17,12,0,@|16,14,0,@|15,14,0,d|15,14,0,@|15,14,2,G|14,14,0,@|13,14,2,G|13,14,0,@|12,14,0,@|11,14,0,@|10,14,0,@|9,14,0,@|8,14,0,@|7,14,0,@|6,14,0,@|5,14,0,@|4,14,0,A|8,16,0,A|9,16,0,@|10,16,0,@|11,16,0,A|12,16,0,@|13,16,0,@|14,16,0,@|15,16,0,@|16,16,0,@|17,16,0,@|16,18,0,@|15,18,0,@|14,18,0,@|13,18,0,@|12,18,0,@|11,18,0,A|10,18,0,@|9,18,0,@|8,18,1,D|8,20,0,A|9,20,0,@|10,20,0,@|11,20,0,A|12,20,0,@|13,20,0,@|14,20,0,@|15,20,0,@|16,20,0,@|17,20,0,@|16,22,0,@|15,22,0,@|14,22,0,@|13,22,0,@|12,22,0,@|11,22,1,D|10,22,0,@|9,22,0,@|8,22,0,A|5,29,1,Z|5,34,1,Z|3,37,0,K|3,39,0,A|1,39,3,e|0,40,0,J|0,42,0,e|1,43,0,J|2,43,2,b|3,43,0,J|4,43,2,b|5,43,0,J|6,43,0,J|7,43,0,J|8,43,0,J|9,43,0,J|10,43,0,J|11,43,0,J|12,43,0,J|13,43,0,J|14,43,0,J|15,43,0,J|16,43,1,^|17,42,0,A|18,42,1,^|19,41,0,A|20,41,1,^|21,40,0,J|22,40,1,^|23,39,0,J|24,39,1,^|25,38,0,J|26,38,1,^|27,37,0,J|28,37,1,^|29,36,0,J|30,36,1,^|31,35,0,A|35,35,0,J|35,36,0,J|35,37,0,J|35,38,0,J|35,39,0,J|35,40,0,J|35,41,0,J|35,42,0,J|35,43,0,J|35,44,0,J|35,45,0,J|36,45,0,J|37,45,0,J|38,45,0,J|39,45,0,J|40,45,0,J|41,45,0,J|42,45,0,J|46,45,0,J|47,45,0,J|48,45,0,J|49,45,0,J|50,45,0,J|51,45,0,J|51,46,0,J|51,47,0,J|51,48,0,J|51,49,0,J|50,49,2,f|50,50,0,J|49,51,0,a|50,52,0,J|51,52,0,J|52,52,0,J|53,52,0,J|54,52,0,J|55,52,0,J|56,52,0,J|57,52,0,J|58,52,0,J|59,52,0,J|60,52,0,J|61,52,0,J|62,52,0,J|63,52,0,J|64,52,0,J|65,52,0,J|65,51,0,A|65,50,0,A|65,49,0,A|65,48,0,A|65,47,0,A|65,46,0,A|65,45,0,A|65,44,0,A|65,43,0,A|65,42,0,A|65,41,0,A|65,40,0,A|65,39,0,A|65,38,0,A|65,37,0,A|65,36,0,A|65,35,0,A|65,34,0,A|65,33,0,A|65,32,1,D|65,31,0,A|65,30,0,A|65,29,0,A|65,28,0,A|65,27,0,A|65,26,3,B|65,25,0,A|65,24,0,A|65,23,0,A|65,22,0,A|65,21,0,A|65,20,1,D|65,19,0,A|65,18,0,A|65,17,0,A|65,16,0,A|65,15,0,A|65,14,0,A|65,13,0,A|65,12,0,A|65,11,0,A|65,10,0,A|65,9,0,A|65,8,0,A|65,7,0,A|65,6,0,A|65,5,0,A|65,4,0,A|65,3,0,A|65,2,0,A|65,1,0,A|65,0,0,J|64,51,0,A|63,51,0,A|62,48,0,g|63,50,0,@|62,50,0,@|61,50,0,@|61,49,0,@|61,48,0,@|61,47,0,@|62,44,0,g|61,46,0,@|61,45,0,@|61,44,0,@|61,43,0,@|62,40,0,g|61,42,0,@|61,41,0,@|61,40,0,@|61,39,0,@|62,36,0,g|61,38,0,@|61,37,0,@|61,36,0,@|61,35,0,@|61,34,0,A|61,33,0,@|61,32,0,@|61,31,0,A|61,28,0,h|61,30,0,@|61,29,0,@|61,28,0,@|61,27,0,@|61,26,0,@|61,25,0,@|61,23,0,h|61,24,0,@|61,23,0,@|61,22,0,@|61,21,0,A|61,20,0,@|61,19,0,@|61,18,0,A|62,15,0,g|61,17,0,@|61,16,0,@|61,15,0,@|61,14,0,@|62,11,0,g|61,13,0,@|61,12,0,@|61,11,0,@|61,10,0,@|62,7,0,g|61,9,0,@|61,8,0,@|61,7,0,@|61,6,0,@|62,3,0,g|61,5,0,@|61,4,0,@|61,3,0,@|61,2,0,@|61,1,0,A|61,0,0,J|62,49,0,@|63,49,0,@|63,48,0,@|63,47,0,@|63,46,0,@|63,45,0,@|63,44,0,@|63,43,0,@|63,42,0,@|63,41,0,@|63,40,0,@|63,39,0,@|63,38,0,@|63,37,0,@|63,36,0,@|63,35,0,@|63,34,0,A|63,33,0,@|62,33,1,E|63,32,0,@|63,31,0,A|63,30,0,@|63,29,0,@|63,28,0,@|63,27,0,@|63,26,0,@|63,25,0,@|63,24,0,@|63,23,0,@|63,22,0,@|63,21,0,A|63,20,0,@|63,19,3,E|63,19,0,@|63,18,0,A|63,17,0,@|63,16,0,@|63,15,0,@|63,14,0,@|63,13,0,@|63,12,0,@|63,11,0,@|63,10,0,@|63,9,0,@|63,8,0,@|63,7,0,@|63,6,0,@|63,5,0,@|63,4,0,@|63,3,0,@|63,2,0,@|63,1,0,A|63,0,0,J|62,51,0,A|61,51,0,A|60,51,0,A|59,51,0,A|58,48,0,g|59,50,0,@|58,50,0,@|57,50,0,@|54,48,0,g|56,50,0,@|55,50,0,@|54,50,0,@|53,50,0,@|53,49,0,@|53,48,0,@|53,47,0,@|54,44,0,g|53,46,0,@|53,45,0,@|53,44,0,@|53,43,0,@|54,40,0,g|53,42,0,@|53,41,0,@|53,40,0,@|53,39,0,@|54,36,0,g|53,38,0,@|53,37,0,@|53,36,0,@|53,35,0,@|53,34,0,A|53,33,0,@|53,32,0,@|53,31,2,B|53,30,0,@|53,29,0,@|53,28,0,@|53,27,0,i|53,27,0,@|53,26,0,@|53,26,0,A|53,25,1,j|53,25,0,@|53,24,0,@|53,24,1,k|53,23,0,@|53,23,1,i|53,22,0,@|53,21,0,B|53,20,0,@|53,19,0,@|53,18,0,A|54,15,0,g|53,17,0,@|53,16,0,@|53,15,0,@|53,14,0,@|54,11,0,g|53,13,0,@|53,12,0,@|53,11,0,@|53,10,0,@|54,7,0,g|53,9,0,@|53,8,0,@|53,7,0,@|53,6,0,@|54,3,0,g|53,5,0,@|53,4,0,@|53,3,0,@|53,2,0,@|53,1,0,A|53,0,0,J|54,49,0,@|55,49,0,@|55,48,0,@|56,48,0,@|57,48,0,@|57,47,0,@|57,46,0,@|57,45,0,@|57,45,0,X|57,44,0,@|57,43,0,@|57,42,0,@|57,41,0,@|57,40,0,@|57,39,0,@|57,38,0,@|57,37,0,@|57,36,0,@|57,36,0,X|57,35,0,@|57,34,0,D|57,33,0,@|57,32,0,@|57,31,0,A|57,30,0,@|57,29,0,@|57,28,0,@|57,27,0,@|57,27,0,k|57,26,0,@|57,26,0,A|57,25,3,j|57,25,0,@|57,24,0,@|57,24,3,k|57,23,0,@|57,23,3,k|57,22,0,@|57,22,3,j|57,21,0,A|57,20,0,@|57,19,0,@|57,18,0,D|57,17,0,@|57,16,0,@|57,16,0,X|57,15,0,@|57,14,0,@|57,13,0,@|57,12,0,@|57,11,0,@|57,10,0,@|57,9,0,@|57,8,0,@|57,7,0,@|57,7,0,X|57,6,0,@|58,3,0,g|57,5,0,@|57,4,0,@|57,3,0,@|57,2,0,@|57,1,0,A|57,0,0,J|56,47,0,@|55,47,0,@|55,46,0,@|55,45,0,@|55,44,0,@|55,43,0,@|55,42,0,@|55,41,0,@|55,40,0,@|55,39,0,@|55,38,0,@|55,37,0,@|55,36,0,@|55,35,0,@|55,34,0,A|55,33,0,@|54,33,1,E|55,32,0,@|55,31,0,A|55,30,0,@|55,29,0,@|55,28,0,@|55,27,0,l|55,27,0,@|55,26,0,@|55,26,0,A|55,25,0,@|55,24,0,@|55,23,0,@|55,22,0,@|55,21,0,A|55,20,0,@|55,19,0,@|55,19,3,E|55,18,0,A|55,17,0,@|55,16,0,@|55,15,0,@|55,14,0,@|55,13,0,@|55,12,0,@|55,11,0,@|55,10,0,@|55,9,0,@|55,8,0,@|55,7,0,@|55,6,0,@|55,5,0,@|55,4,0,@|55,3,0,@|55,2,0,@|55,1,0,A|55,0,0,J|56,49,0,@|57,49,0,@|58,49,0,@|59,49,0,@|59,48,0,@|59,47,0,@|59,46,0,@|59,46,0,m|58,44,0,_|59,45,0,@|59,44,0,@|58,42,0,_|59,43,0,@|59,42,0,@|58,40,0,_|59,41,0,@|59,40,0,@|58,38,0,_|59,39,0,@|59,38,0,@|58,36,0,_|59,37,0,@|59,36,0,@|59,35,0,@|59,34,0,B|59,33,0,@|59,32,0,@|59,31,0,A|59,28,0,h|59,30,0,@|59,29,0,@|59,28,0,@|59,27,0,@|59,26,0,@|59,25,0,@|59,23,0,h|59,24,0,@|59,23,0,@|59,22,0,@|59,21,0,A|59,20,0,@|59,19,0,@|59,18,2,B|59,17,0,@|59,16,0,@|58,15,0,_|59,15,0,@|58,13,0,_|59,14,0,@|59,13,0,@|59,12,0,@|58,11,0,_|59,11,0,@|58,9,0,_|59,10,0,@|59,9,0,@|59,8,0,@|58,7,0,_|59,7,0,@|59,6,0,@|59,6,0,m|59,5,0,@|59,4,0,@|59,3,0,@|59,2,0,@|59,1,0,A|59,0,0,J|58,51,0,A|57,51,0,A|56,51,0,A|55,51,0,A|54,51,0,A|53,51,0,A|52,51,0,A|51,51,0,A|50,51,0,J|51,50,0,J|52,49,0,A|52,48,0,A|52,47,0,A|52,46,0,A|52,45,0,A|51,44,0,A|51,43,0,A|50,43,2,L|50,43,0,@|49,43,0,@|48,43,2,G|48,43,0,@|47,43,0,@|46,43,0,@|46,43,0,A|45,34,0,A|45,33,0,@|45,32,0,@|45,31,0,@|45,31,0,A|45,30,0,@|44,30,2,n|45,29,0,@|45,28,0,@|45,27,0,@|45,26,0,@|45,25,0,@|45,24,0,@|45,23,0,@|45,22,0,@|45,21,0,@|45,21,0,A|45,20,0,@|45,19,0,@|45,19,3,E|45,18,0,A|45,17,0,@|45,17,0,o|45,16,0,@|45,15,0,@|45,15,2,S|44,13,0,p|45,14,0,@|45,13,0,@|45,12,0,@|45,12,0,S|45,11,0,@|45,10,0,@|45,9,0,@|45,8,0,A|45,7,0,J|41,34,0,A|41,33,0,@|42,33,0,@|42,32,0,@|43,32,0,@|43,31,0,@|43,31,0,A|37,34,0,A|37,33,0,@|38,33,0,@|39,33,0,@|38,34,0,A|39,34,0,D|46,42,0,@|47,42,0,@|47,41,0,@|47,41,0,A|48,41,0,@|49,41,0,@|49,41,0,A|50,41,0,@|50,41,0,A|51,41,0,A|51,40,0,A|51,39,0,A|50,39,0,@|49,39,0,@|48,39,0,@|47,39,0,@|47,38,0,@|47,37,0,@|48,37,0,@|49,37,0,@|50,37,3,q|50,37,0,@|51,37,0,A|51,36,0,A|51,35,0,A|50,35,3,q|50,35,0,@|49,35,0,@|48,35,0,@|47,35,0,@|47,34,0,B|47,33,0,@|48,33,0,@|49,33,0,@|49,32,0,@|49,31,0,@|49,31,0,A|49,30,0,@|49,29,0,@|49,28,0,@|49,27,0,@|49,26,0,@|49,25,0,@|49,24,0,@|49,23,0,@|49,22,0,@|49,21,0,@|49,21,0,A|49,20,0,@|49,19,0,@|49,19,3,E|49,18,0,A|49,17,0,@|49,17,2,S|49,16,0,@|48,15,0,r|49,15,0,@|49,14,0,@|49,14,0,S|49,13,0,@|49,12,0,@|49,11,0,@|49,11,0,A|50,10,2,L|49,10,0,@|49,9,0,@|49,8,0,A|49,7,0,J|48,32,0,@|47,32,0,@|47,31,0,@|47,31,0,A|47,30,0,@|47,29,0,@|47,28,0,@|47,27,0,@|47,26,0,@|47,25,0,@|47,24,0,@|47,23,0,@|47,22,0,@|47,21,0,@|47,21,0,A|47,20,0,@|47,19,0,@|47,18,2,B|47,17,0,@|47,16,0,@|47,15,0,@|47,14,0,@|47,13,0,@|47,12,0,@|47,11,0,@|47,11,0,A|47,10,0,@|47,10,0,A|47,9,0,@|47,9,1,D|47,8,0,A|47,7,0,J|48,34,0,D|49,34,0,A|50,34,0,A|51,34,0,A|51,33,3,B|51,32,1,D|51,31,0,A|51,30,0,A|51,29,0,A|51,28,0,A|51,27,0,A|51,26,3,B|51,25,0,A|51,24,0,A|51,23,0,A|51,22,0,A|51,21,0,A|51,20,1,D|51,19,3,B|51,18,0,A|51,17,0,A|51,16,0,A|51,15,0,A|51,14,0,A|51,13,0,A|51,12,0,A|51,11,0,A|51,10,0,A|51,9,0,A|51,8,0,A|51,7,0,J|51,6,0,J|51,5,0,J|51,4,0,J|51,3,0,J|50,3,0,s|50,2,0,J|49,1,0,e|50,0,0,J|51,0,0,J|51,1,0,J|50,1,0,J|51,2,0,J|50,36,0,@|49,36,0,@|48,36,0,@|47,36,0,@|48,38,0,@|49,38,0,@|50,38,3,q|50,38,0,@|51,38,0,A|50,40,3,q|50,40,0,@|49,40,0,@|48,40,0,@|47,40,0,@|48,42,0,@|49,42,0,@|50,42,0,@|51,42,0,A|50,44,0,A|49,44,0,A|48,44,0,A|47,44,0,A|46,44,0,A|45,44,0,A|43,44,0,A|42,44,0,A|41,44,0,A|40,44,0,A|39,44,0,A|38,44,0,A|37,44,0,A|36,44,0,A|36,43,0,A|36,42,0,A|36,41,0,A|36,40,0,A|36,39,0,A|36,38,0,A|36,37,0,A|36,36,0,A|36,35,0,A|35,34,0,A|35,32,3,G|35,33,2,t|35,33,0,@|34,33,0,@|33,33,0,@|32,33,0,@|31,33,0,@|31,33,0,A|30,33,1,u|30,33,0,@|29,33,0,@|29,33,1,S|28,33,0,@|27,33,0,@|26,33,0,@|25,33,0,@|24,33,0,@|23,33,0,@|22,33,0,@|21,33,0,@|20,32,3,v|20,33,0,@|19,33,0,A|18,33,0,@|18,33,0,X|17,33,0,@|17,33,0,X|14,34,0,Y|16,33,0,@|15,33,0,@|14,33,0,@|13,33,0,@|12,33,0,@|11,33,0,A|10,33,0,[|10,33,0,@|10,33,3,G|9,33,0,@|9,34,0,@|9,35,0,A|10,35,0,A|11,35,0,A|12,35,0,@|13,35,0,@|14,35,0,@|15,35,0,@|16,35,0,@|17,35,0,@|17,35,0,]|18,35,0,@|18,35,0,]|19,35,0,A|21,36,3,w|20,35,0,@|21,35,0,@|22,35,0,@|23,35,0,@|24,35,0,@|25,35,0,@|26,35,0,@|27,35,0,@|28,35,0,A|9,32,0,@|8,32,0,A|8,31,0,A|8,30,0,A|8,29,1,D|8,28,0,A|8,27,0,A|9,27,0,@|10,27,0,@|11,27,0,A|12,27,0,@|13,27,0,@|14,27,0,@|15,27,0,@|16,27,0,@|17,27,0,@|17,27,0,]|18,27,0,@|18,27,0,]|18,28,0,@|19,28,3,B|19,29,1,D|20,29,0,@|21,29,0,@|22,29,0,@|23,29,0,@|23,28,2,B|24,28,0,D|25,28,0,A|26,28,0,A|27,28,0,A|28,28,0,A|29,28,0,A|29,29,0,@|29,29,1,D|30,29,0,@|30,30,0,@|31,30,0,@|32,30,0,@|32,31,0,@|32,31,0,A|33,31,0,@|33,31,0,D|9,31,0,@|10,31,0,@|10,31,3,G|11,31,0,A|11,30,1,D|11,29,3,B|12,29,0,@|13,29,3,\|13,29,0,@|14,29,0,@|15,29,0,G|15,29,0,[|15,29,0,@|16,29,0,[|16,29,0,@|17,29,0,@|17,30,0,@|18,30,0,@|18,31,0,@|19,31,0,A|20,31,0,@|21,31,0,@|22,31,0,@|23,31,0,@|24,31,0,@|24,30,0,@|25,30,0,@|26,30,0,@|27,30,0,@|28,30,0,@|28,30,3,G|28,31,0,@|29,31,0,@|29,31,0,A|10,30,0,@|10,34,0,@|10,32,0,[|10,32,0,@|11,34,0,A|11,32,0,A|12,34,0,@|12,32,0,@|13,34,0,@|13,32,0,@|13,31,0,@|13,31,3,\|14,31,0,@|15,31,0,@|16,31,2,G|16,31,0,@|14,34,0,@|14,32,0,@|15,34,0,@|15,32,0,@|16,34,0,@|16,32,0,@|17,34,0,@|17,32,0,@|18,34,0,@|18,32,0,@|19,34,0,A|19,32,0,A|20,34,0,@|20,32,0,@|21,34,0,@|21,32,0,@|21,32,2,x|22,34,0,@|22,32,0,@|23,34,0,@|23,32,0,@|24,34,0,@|24,32,0,@|24,32,0,y|25,34,0,@|25,32,0,@|26,34,0,@|26,32,0,@|27,34,0,@|27,32,0,@|28,34,0,@|28,32,0,@|29,34,0,@|29,32,0,@|30,34,0,@|30,32,0,@|31,32,0,@|31,32,0,A|32,32,0,@|33,32,0,@|34,32,0,@|34,34,2,B|32,34,0,A|31,34,0,A|30,35,0,A|29,35,0,A|28,36,0,A|27,36,0,A|26,37,0,A|25,37,0,A|24,37,0,A|23,37,0,@|22,37,0,@|21,37,0,@|20,37,0,@|19,37,0,A|18,37,0,A|17,37,0,D|16,37,0,A|15,37,0,A|14,37,0,A|13,37,0,A|12,37,0,A|11,37,0,B|9,36,0,_|10,37,0,@|9,37,0,@|8,37,0,A|7,37,0,A|6,37,0,A|5,37,0,A|6,39,2,`|5,38,0,@|5,39,0,@|5,41,2,L|5,40,0,@|4,40,0,@|4,41,0,@|3,41,0,A|2,41,0,J|5,41,0,@|6,41,0,@|7,41,3,\|7,41,0,@|8,40,0,_|8,41,0,@|9,41,0,@|10,40,0,_|10,41,0,@|11,41,0,@|12,40,0,_|12,41,0,@|13,41,0,@|14,40,0,c|14,41,0,@|15,41,0,@|16,41,0,@|16,41,2,\|16,40,0,@|18,40,2,L|17,40,0,@|18,40,0,@|18,39,0,@|19,39,0,A|20,39,0,A|17,39,0,@|16,39,0,@|15,39,0,@|14,39,0,@|13,39,0,@|12,39,0,@|11,39,0,@|10,39,0,@|9,39,0,@|8,39,0,@|7,39,0,@|15,40,0,@|14,40,0,@|13,40,0,@|12,40,0,@|11,40,0,@|10,40,0,@|9,40,0,@|8,40,0,@|7,40,0,@|6,40,0,@|6,39,0,@|6,38,0,@|7,38,0,@|8,38,0,@|8,36,0,A|9,38,0,@|10,38,0,@|11,38,0,@|12,38,0,G|12,38,0,@|13,38,0,@|14,38,0,G|14,38,0,@|15,38,0,d|15,38,0,@|16,38,0,@|17,38,0,@|18,38,0,@|19,38,0,A|20,38,0,@|21,38,0,@|22,38,0,A|24,38,0,A|23,38,0,A|22,39,0,A|21,39,0,A|20,40,0,J|19,40,0,A|18,41,0,A|17,41,0,A|16,42,0,A|15,42,0,A|14,42,0,A|13,42,0,A|12,42,0,A|11,42,0,A|10,42,0,A|9,42,0,A|8,42,0,A|7,42,0,A|6,42,0,A|5,42,0,A|4,42,0,A|3,42,0,A|2,42,0,A|1,42,0,J|1,41,0,J|1,40,0,J|2,40,0,J|3,40,0,A|4,39,0,A|4,38,0,A|4,37,0,A|8,26,0,A|8,24,0,A|9,26,0,@|9,26,0,D|9,24,0,@|10,26,0,@|10,26,0,A|10,24,0,@|11,26,0,A|11,24,0,A|12,26,0,@|12,24,0,@|13,26,0,@|13,24,0,@|14,26,0,@|14,24,0,@|15,26,0,@|15,24,0,@|16,26,0,@|16,24,0,@|17,26,0,@|17,24,0,@|18,26,0,@|18,24,0,@|18,23,0,@|20,22,0,@|18,22,0,@|20,21,0,@|18,21,0,@|20,20,0,@|18,20,0,@|20,19,0,@|18,19,0,@|18,19,0,]|20,18,0,@|18,18,0,@|20,17,0,@|18,17,0,@|18,17,0,X|20,15,3,z|20,16,0,@|18,16,0,@|20,15,0,@|18,15,0,A|20,14,0,@|18,14,0,@|20,13,0,A|18,13,0,@|20,12,0,J|18,12,0,@|18,11,0,A|19,26,0,A|20,28,0,A|19,27,0,A|21,28,0,A|23,27,0,@|22,28,0,A|24,27,0,@|25,27,0,@|26,27,0,@|26,27,0,A|27,27,0,@|28,27,0,@|29,27,0,@|30,28,2,B|31,29,0,@|32,29,0,@|33,30,0,@|34,31,0,@|34,31,0,A|35,32,2,{|35,32,0,@|36,32,0,A|37,32,0,@|38,32,0,@|39,32,0,@|40,32,0,@|42,31,0,@|42,31,0,A|41,32,0,@|43,30,0,@|44,29,0,@|44,29,0,}|44,28,0,@|44,28,1,}|44,27,0,@|44,26,0,@|44,25,0,@|44,24,0,@|44,24,2,}|44,23,0,@|44,22,0,@|44,21,0,@|44,21,0,A|44,20,0,@|44,19,0,@|44,18,0,A|44,17,0,@|44,17,1,S|44,16,0,@|44,15,0,@|44,15,2,S|44,14,0,@|44,13,0,@|44,12,0,@|44,11,0,@|44,10,0,@|44,10,0,S|44,9,0,@|44,8,0,A|44,7,0,J|26,22,0,@|26,21,0,@|26,20,0,@|24,20,0,@|26,19,0,@|24,19,0,@|26,18,0,@|26,18,0,y|24,18,0,@|26,17,0,@|24,17,0,@|26,16,0,A|24,16,0,@|26,15,0,A|24,15,0,A|24,14,0,A|22,18,0,@|22,17,0,@|22,16,0,@|22,15,0,@|22,14,0,A|22,13,0,A|11,11,0,@|11,10,0,A|11,9,0,J|9,9,0,J|5,9,0,J|66,52,0,J|67,51,2,e|66,51,0,J|66,50,0,J|64,50,0,@|66,49,0,J|64,49,0,@|66,48,0,J|64,48,0,@|66,47,0,J|64,47,0,@|66,46,0,J|64,46,0,@|66,45,0,J|64,45,0,@|66,44,0,J|64,44,0,@|66,43,0,J|64,43,0,@|66,42,0,J|64,42,0,@|66,41,0,J|64,41,0,@|66,40,0,J|64,40,0,@|66,39,0,J|64,39,0,@|66,38,0,J|64,38,0,@|66,37,0,J|64,37,0,@|66,36,0,J|64,36,0,@|66,35,0,J|67,35,0,J|68,35,0,J|69,35,0,J|70,35,0,J|71,35,0,J|72,35,0,J|73,35,0,J|74,35,0,J|75,35,0,J|76,35,0,J|77,35,0,J|78,35,0,J|79,35,0,J|80,35,0,J|81,35,0,J|82,35,0,J|83,35,0,J|84,35,0,J|84,36,0,J|84,37,0,J|84,38,0,J|84,40,0,e|85,41,0,J|86,41,0,J|87,41,0,J|88,41,0,J|89,41,0,J|90,41,0,J|91,41,0,J|92,41,0,J|93,41,0,J|94,41,0,J|95,41,0,J|96,41,0,J|97,41,0,J|98,40,2,a|97,39,0,A|96,39,2,L|96,39,0,@|95,39,0,@|94,39,0,@|94,39,0,~|93,39,0,@|92,39,0,@|91,39,0,@|90,39,0,@|89,39,0,@|88,39,0,@|87,39,0,@|86,39,0,@|86,39,0,~|86,38,0,@|86,37,0,@|87,37,0,@|90,35,0,|88,37,0,@|89,37,0,@|90,37,0,@|91,37,0,@|92,37,0,@|93,37,0,@|94,37,0,@|96,37,2,L|95,37,0,@|96,37,0,@|97,37,0,A|98,37,0,J|98,36,0,J|98,35,0,J|97,35,0,A|96,35,0,@|96,35,3,\|95,35,0,@|94,35,0,@|93,35,0,@|92,35,0,@|90,35,0,|91,35,0,@|90,35,0,@|89,35,0,@|88,35,0,@|87,35,0,@|86,35,0,@|86,34,0,@|85,34,0,A|85,33,1,B|84,33,3,B|83,33,0,@|82,33,0,@|81,33,1,E|81,33,0,@|80,33,0,@|79,33,0,@|78,33,0,@|77,33,0,@|76,33,0,@|75,33,0,@|74,33,0,@|73,33,0,@|72,33,0,@|71,33,0,@|70,33,0,@|68,33,1,E|69,33,0,@|68,33,0,@|67,33,0,@|67,32,0,@|67,31,0,A|68,31,0,A|69,31,0,A|70,31,0,A|71,31,0,A|72,31,0,A|73,31,0,A|74,31,0,A|75,31,0,D|76,31,0,A|77,31,0,A|78,31,0,A|79,31,0,A|80,31,0,A|81,31,0,A|82,31,0,A|83,31,0,A|84,31,0,A|85,31,0,A|86,31,0,@|86,31,0,~|86,32,0,@|87,32,0,@|87,33,0,@|88,33,0,@|89,33,0,@|90,33,0,@|91,33,0,@|92,33,0,@|93,33,0,@|94,33,0,@|95,33,0,U|95,33,0,@|95,33,3,G|96,33,0,@|96,33,0,A|98,33,2,`|97,33,0,@|98,33,0,@|100,33,2,`|99,33,0,@|99,34,0,A|100,34,0,A|100,35,2,b|101,35,0,J|102,35,0,J|102,34,0,J|102,33,0,J|101,33,0,A|101,32,0,A|100,32,0,@|100,31,0,@|99,31,0,@|98,31,0,@|97,31,0,@|96,31,0,@|96,31,1,D|95,31,0,@|94,31,0,@|94,31,0,~|93,31,0,@|92,31,0,@|91,31,0,@|90,31,0,@|89,31,0,@|88,31,0,@|88,30,0,A|87,30,0,A|87,29,0,@|87,29,3,\|86,29,0,@|85,29,0,A|84,29,0,A|83,29,0,@|80,29,0,|82,29,0,@|81,29,0,@|80,29,0,@|79,29,0,@|78,29,0,@|77,29,0,@|77,29,0,A|76,29,0,|76,29,0,@|76,29,3,G|75,29,0,@|74,29,0,|74,29,0,@|74,30,1,G|73,29,0,@|73,29,0,A|72,29,0,@|69,29,0,|71,29,0,@|70,29,0,@|69,29,0,@|68,29,0,@|67,29,0,@|67,28,0,@|67,27,0,@|69,26,0,|68,27,0,@|69,27,0,@|70,27,0,@|71,27,0,@|72,27,0,@|73,27,0,@|73,27,0,A|74,27,0,@|75,26,0,O|75,27,0,@|76,27,0,@|77,27,0,@|77,27,0,A|78,27,0,@|80,26,0,|79,27,0,@|80,27,0,@|81,27,0,@|82,27,0,@|83,27,0,@|84,27,0,A|85,27,0,A|86,27,0,@|87,26,2,|87,27,0,@|88,27,0,@|88,28,0,@|89,28,0,@|89,29,0,@|90,29,0,@|91,29,0,@|92,29,0,@|93,29,0,@|94,29,0,@|95,29,0,@|96,29,0,@|97,29,0,@|98,29,0,@|99,29,0,@|100,29,0,@|101,29,0,@|101,30,0,A|102,30,0,A|102,31,0,J|103,31,0,J|104,31,0,J|105,31,0,J|106,31,0,J|107,31,0,J|108,30,2,a|107,29,0,J|106,29,0,A|105,29,0,@|104,29,0,@|103,29,0,@|103,26,1,|103,28,0,@|102,26,1,|102,28,0,@|102,27,0,@|101,27,0,@|101,26,1,|100,27,0,@|100,26,1,|99,27,0,@|99,26,1,|98,27,0,@|98,26,1,|97,27,0,@|97,26,1,|96,27,0,@|96,26,1,|95,27,0,@|95,26,1,|94,27,0,@|94,26,1,|93,27,0,@|93,26,1,|91,26,1,|92,27,0,@|91,27,0,@|90,27,0,@|90,26,0,@|89,26,0,@|89,25,0,@|88,25,0,@|87,25,0,@|86,25,0,@|85,25,0,A|84,25,0,A|83,25,0,@|82,25,0,@|81,25,0,@|80,25,0,@|79,25,0,@|78,25,0,@|77,25,0,@|77,25,0,A|76,25,0,@|75,25,0,@|74,25,0,@|73,25,0,@|73,25,0,A|72,25,0,@|71,25,0,@|70,25,0,@|69,25,0,@|68,25,0,@|67,25,0,@|69,23,0,|67,24,0,@|67,23,0,@|68,23,0,@|69,23,0,@|70,23,0,@|71,23,0,@|72,23,0,@|73,23,0,@|73,23,0,A|75,23,0,@|76,23,0,|76,23,0,@|76,22,3,G|77,23,0,@|77,23,0,A|80,23,0,|78,23,0,@|79,23,0,@|80,23,0,@|81,23,0,@|82,23,0,@|83,23,0,@|84,23,0,A|85,23,0,A|86,23,0,@|87,23,3,\|87,23,0,@|88,23,0,@|89,23,0,@|90,23,0,@|91,23,0,@|91,22,0,A|91,21,0,@|91,20,0,@|90,17,0,|91,19,0,@|91,18,0,@|91,17,0,@|91,16,0,@|91,15,0,@|91,14,0,@|91,13,0,@|91,12,0,A|91,11,0,J|90,22,0,A|89,22,0,D|89,21,0,@|88,21,0,@|87,21,0,@|87,20,0,@|87,19,0,@|87,18,0,@|87,17,0,@|87,16,0,@|87,15,0,@|87,14,0,@|87,13,0,@|87,12,0,A|87,11,0,J|88,20,0,@|89,20,0,@|89,19,0,@|89,18,0,@|89,17,0,@|89,16,0,@|89,15,0,@|89,14,0,@|89,13,0,@|89,12,0,A|89,11,0,J|88,22,0,A|87,22,0,A|86,22,0,A|85,22,0,A|85,21,0,A|84,21,0,A|83,21,0,A|82,21,0,A|81,21,0,A|80,21,0,A|79,21,0,A|79,20,0,@|79,19,0,@|79,18,0,A|79,17,0,J|80,20,0,@|81,20,0,@|81,19,0,@|82,19,3,E|82,19,0,@|83,19,0,@|83,18,0,A|83,17,0,J|82,18,0,A|81,18,0,A|81,17,0,J|82,20,0,@|83,20,0,@|84,20,0,@|85,20,1,D|85,19,1,B|85,18,0,A|85,17,0,A|85,16,0,A|84,16,0,J|84,15,0,J|84,14,0,J|85,14,0,A|85,13,0,A|85,12,0,A|84,12,0,a|85,11,0,J|85,15,0,A|84,22,0,A|83,22,0,@|82,22,0,@|81,22,0,@|80,22,0,@|79,22,0,@|78,22,0,@|77,22,0,@|77,22,0,A|77,21,0,A|76,21,0,A|75,21,0,D|74,21,0,A|73,21,0,A|72,21,0,A|71,21,0,A|70,21,0,A|69,21,0,A|68,21,0,A|67,21,0,A|67,20,0,@|67,19,0,@|68,19,0,@|69,19,3,E|69,19,0,@|70,19,0,@|71,19,0,@|71,18,0,A|71,17,0,J|70,18,0,A|69,18,0,A|69,17,0,J|68,17,0,J|67,17,0,J|68,18,0,A|67,18,0,A|68,20,0,@|69,20,0,@|70,20,0,@|71,20,0,@|72,20,0,@|73,20,0,@|73,19,0,@|74,19,0,@|75,19,0,@|76,19,0,@|77,19,0,@|77,18,0,A|77,17,0,J|76,17,0,J|75,17,0,J|74,17,0,J|73,17,0,J|76,18,0,A|75,18,0,A|74,18,0,A|73,18,0,A|74,20,0,@|75,20,0,@|76,20,0,@|77,20,0,@|76,22,0,|76,22,0,@|75,22,0,@|74,22,0,@|73,22,0,@|73,22,0,A|72,22,0,@|71,22,0,@|70,22,0,@|69,22,0,@|68,22,0,@|67,22,0,@|68,24,0,@|69,24,0,@|70,24,0,@|71,24,0,@|72,24,0,@|73,24,0,@|73,24,1,D|74,24,0,@|75,24,0,@|76,24,0,@|77,24,0,@|77,24,1,D|78,24,0,@|79,24,0,@|80,24,0,@|81,24,0,@|82,24,0,@|83,24,0,@|84,24,0,A|85,24,0,A|86,24,0,@|87,24,0,@|88,24,0,@|89,24,0,@|90,25,0,@|91,25,0,@|92,25,0,@|93,25,0,@|94,25,0,@|95,25,0,@|96,25,0,@|97,25,0,@|98,25,0,@|99,25,0,@|100,25,0,@|101,25,0,@|102,25,0,@|103,25,0,@|103,26,0,@|104,26,1,|104,26,0,@|104,27,0,@|105,27,0,@|105,26,1,|107,26,1,|105,25,0,@|105,24,0,@|104,24,0,@|104,23,0,@|103,23,0,@|102,23,0,@|101,23,0,@|100,23,0,@|99,23,0,@|98,23,0,@|97,23,0,@|96,23,0,@|95,23,0,@|94,23,0,@|93,23,0,@|93,22,0,A|93,21,0,@|94,21,0,@|94,21,0,~|95,21,0,@|96,21,0,@|96,21,1,D|97,21,0,@|98,21,0,@|99,21,0,@|100,21,0,@|101,21,0,A|102,21,0,J|103,21,0,J|104,21,0,J|105,21,0,J|106,21,0,J|102,20,0,J|102,19,0,J|101,19,0,A|100,19,0,@|100,20,2,`|99,19,0,@|99,18,0,A|99,17,0,J|100,18,0,A|101,18,0,A|101,17,0,J|102,17,0,J|102,18,0,J|101,20,0,A|100,20,0,@|99,20,0,@|98,20,2,`|98,20,0,@|97,20,0,@|97,19,0,@|96,19,0,@|96,19,0,A|95,18,3,G|95,19,0,@|94,19,0,@|93,19,0,@|93,18,0,@|93,17,0,@|94,17,0,@|95,17,0,@|96,17,3,\|96,17,0,@|97,17,0,A|97,16,0,A|98,16,0,J|98,15,0,J|98,14,0,J|98,12,2,e|97,15,0,A|96,15,0,@|96,16,2,L|95,15,0,@|96,14,2,L|95,14,0,@|95,13,0,@|95,12,0,A|95,11,0,J|96,14,0,@|96,16,0,@|95,16,0,@|94,16,0,@|93,16,0,@|93,15,0,@|93,14,0,@|93,13,0,@|93,12,0,A|93,11,0,J|94,18,0,@|95,18,0,@|96,18,0,@|96,18,0,A|97,18,0,A|96,20,0,@|96,20,0,A|95,20,0,@|94,20,0,@|93,20,0,@|94,22,0,A|95,22,0,A|96,22,0,A|97,22,0,A|98,22,0,A|99,22,0,A|100,22,0,A|101,22,0,A|102,22,0,A|103,22,0,A|104,22,0,A|105,23,0,@|106,23,0,A|107,23,0,J|108,22,2,e|107,22,0,J|105,26,0,@|104,25,0,@|103,24,0,@|102,24,0,@|101,24,0,@|100,24,0,@|99,24,0,@|98,24,0,@|97,24,0,@|96,24,0,@|95,24,0,@|94,24,0,@|93,24,0,@|92,24,0,@|91,26,0,@|92,26,0,@|93,26,0,@|94,26,0,@|95,26,0,@|96,26,0,@|97,26,0,@|98,26,0,@|99,26,0,@|100,26,0,@|101,26,0,@|102,26,0,@|103,27,0,@|104,28,0,@|105,28,0,@|107,30,0,J|106,30,0,A|105,30,0,A|104,30,0,A|103,30,0,A|102,29,0,@|101,28,0,@|100,28,0,@|99,28,0,@|98,28,0,@|97,28,0,@|96,28,0,@|95,28,0,@|94,28,0,@|93,28,0,@|92,28,0,@|91,28,0,@|90,28,0,@|89,27,0,@|88,26,0,@|87,26,0,@|86,26,0,@|85,26,1,B|84,26,0,A|83,26,0,@|82,26,0,@|81,26,0,@|80,26,0,@|79,26,0,@|78,26,0,@|77,26,0,@|77,26,0,A|76,26,0,@|75,26,0,@|74,26,0,@|73,26,0,@|73,26,1,B|72,26,0,@|71,26,0,@|70,26,0,@|69,26,0,@|68,26,0,@|67,26,0,@|68,28,0,@|69,28,0,@|70,28,0,@|71,28,0,@|72,28,0,@|73,28,0,@|73,28,1,D|74,28,0,@|75,28,0,@|76,28,0,@|77,28,0,@|77,28,1,D|78,28,0,@|79,28,0,@|80,28,0,@|81,28,0,@|82,28,0,@|83,28,0,@|84,28,0,A|85,28,0,A|86,28,0,@|87,28,0,@|88,29,0,@|89,30,0,D|90,30,0,A|91,30,0,A|92,30,0,A|93,30,0,A|94,30,0,A|95,30,0,A|96,30,0,A|97,30,0,A|98,30,0,A|99,30,0,A|100,30,0,A|101,31,0,A|102,32,0,J|101,34,0,A|100,33,0,@|99,32,0,@|98,32,0,@|97,32,0,@|96,32,0,@|96,32,0,A|95,32,0,@|94,32,0,@|93,32,0,@|92,32,0,@|91,32,0,@|90,32,0,@|89,32,0,@|88,32,0,@|87,31,0,@|86,30,0,A|85,30,0,A|84,30,0,A|83,30,0,@|82,30,0,@|81,30,0,@|80,30,0,@|79,30,0,@|78,30,0,@|77,30,0,@|77,30,0,A|76,30,0,|76,30,0,@|75,30,0,@|74,30,0,|74,30,0,@|73,30,0,@|73,30,0,A|72,30,0,@|71,30,0,@|70,30,0,@|69,30,0,@|68,30,0,@|67,30,0,@|68,32,0,@|69,32,0,@|70,32,0,@|71,32,0,@|72,32,0,@|73,32,0,@|74,32,0,@|75,32,0,@|76,32,0,@|77,32,0,@|78,32,0,@|79,32,0,@|80,32,0,@|81,32,0,@|82,32,0,@|83,32,0,@|84,32,0,@|85,32,1,D|86,33,0,@|87,34,0,@|88,34,0,@|89,34,0,@|90,34,0,@|91,34,0,@|92,34,0,@|93,34,0,@|94,34,0,@|95,34,0,@|96,34,0,@|96,34,0,A|97,34,0,A|99,35,0,J|98,34,0,A|97,36,0,A|96,36,0,@|95,36,0,@|94,36,0,@|93,36,0,@|92,36,0,@|91,36,0,@|90,36,0,@|89,36,0,@|88,36,0,@|87,36,0,@|86,36,0,@|87,38,0,@|88,38,0,@|89,38,0,@|90,38,0,@|91,38,0,@|92,38,0,@|93,38,0,@|94,38,0,@|95,38,0,@|96,38,0,@|97,38,0,A|98,38,0,J|97,40,0,A|96,40,0,A|95,40,0,A|94,40,0,A|93,40,0,A|92,40,0,A|91,40,0,A|90,40,0,A|89,40,0,A|88,40,0,A|87,40,0,A|86,40,0,A|85,40,0,A|85,39,0,A|85,38,0,A|85,37,0,A|85,36,0,A|85,35,0,A|84,34,0,A|83,34,0,A|82,34,0,A|81,34,0,A|80,34,0,A|79,34,0,A|78,34,0,A|77,34,0,A|76,34,0,A|75,34,0,A|74,34,0,A|73,34,0,A|72,34,0,A|71,34,0,A|70,34,0,A|69,34,0,A|68,34,0,A|67,34,0,A|64,35,0,@|66,34,0,A|64,34,0,A|66,33,0,A|64,33,0,@|66,32,0,@|64,32,0,@|66,31,0,A|64,31,0,A|66,30,0,A|64,28,0,h|64,30,0,@|66,29,0,A|64,29,0,@|66,28,0,A|64,28,0,@|66,27,0,A|64,27,0,@|66,26,0,A|64,26,0,@|66,25,0,A|64,25,0,@|64,23,0,h|66,24,0,A|64,24,0,@|66,23,0,A|64,23,0,@|66,22,0,A|64,22,0,@|66,21,0,A|64,21,0,A|66,20,0,@|64,20,0,@|66,19,0,A|64,19,0,@|66,18,0,A|64,18,0,A|66,17,0,J|64,17,0,@|66,16,0,J|64,16,0,@|66,15,0,J|64,15,0,@|66,14,0,J|64,14,0,@|66,13,0,J|64,13,0,@|66,12,0,J|64,12,0,@|66,11,0,J|64,11,0,@|66,10,0,J|64,10,0,@|66,9,0,J|64,9,0,@|66,8,0,J|64,8,0,@|66,7,0,J|64,7,0,@|66,6,0,J|64,6,0,@|66,5,0,J|64,5,0,@|66,4,0,J|64,4,0,@|66,3,0,J|64,3,0,@|66,2,0,J|67,1,2,a|64,2,0,@|66,1,0,J|64,1,0,A|66,0,0,J|64,0,0,J|60,50,0,@|60,49,0,@|62,48,0,@|60,48,0,@|62,47,0,@|60,47,0,@|62,46,0,@|60,46,0,@|62,45,0,@|60,45,0,@|60,45,0,X|62,44,0,@|60,44,0,@|62,43,0,@|60,43,0,@|62,42,0,@|60,42,0,@|62,41,0,@|60,41,0,@|62,40,0,@|60,40,0,@|62,39,0,@|60,39,0,@|62,38,0,@|60,38,0,@|62,37,0,@|60,37,0,@|62,36,0,@|60,36,0,@|60,36,0,X|62,35,0,@|60,35,0,@|62,34,0,A|62,33,0,@|60,33,0,@|62,32,0,@|60,32,0,@|62,31,0,A|60,31,0,D|62,28,0,h|62,30,0,@|60,30,0,@|62,29,0,@|60,29,0,@|62,28,0,@|60,28,0,@|62,27,0,@|60,27,0,@|62,26,0,@|60,26,0,@|62,25,0,@|62,23,0,h|60,25,0,@|62,24,0,@|60,24,0,@|62,23,0,@|60,23,0,@|62,22,0,@|60,22,0,@|62,21,0,A|60,21,0,D|62,20,0,@|60,20,0,@|62,19,0,@|60,19,0,@|62,18,0,A|62,17,0,@|60,17,0,@|62,16,0,@|60,16,0,@|60,16,0,X|62,15,0,@|60,15,0,@|62,14,0,@|60,14,0,@|62,13,0,@|60,13,0,@|62,12,0,@|60,12,0,@|62,11,0,@|60,11,0,@|62,10,0,@|60,10,0,@|62,9,0,@|60,9,0,@|62,8,0,@|60,8,0,@|62,7,0,@|60,7,0,@|60,7,0,X|62,6,0,@|60,6,0,@|62,5,0,@|60,5,0,@|62,4,0,@|60,4,0,@|62,3,0,@|60,3,0,@|62,2,0,@|60,2,0,@|62,1,0,A|60,1,0,A|62,0,0,J|60,0,0,J|52,50,0,A|54,48,0,@|54,47,0,@|54,46,0,@|54,45,0,@|54,44,0,@|52,44,0,A|54,43,0,@|52,43,0,A|54,42,0,@|52,42,0,A|54,41,0,@|52,41,0,A|54,40,0,@|52,40,0,A|54,39,0,@|52,39,0,A|54,38,0,@|52,38,0,A|54,37,0,@|52,37,0,A|54,36,0,@|52,36,0,A|54,35,0,@|52,35,0,A|54,34,0,A|52,34,0,A|54,33,0,@|52,33,1,B|54,32,0,@|52,32,0,@|54,31,0,D|52,31,0,A|54,30,0,@|52,30,0,A|54,29,0,@|52,29,0,A|54,28,0,@|52,28,0,A|54,27,0,@|52,27,0,A|54,26,0,@|54,26,0,A|52,26,0,A|54,25,0,@|52,25,0,A|54,24,0,@|52,24,0,A|54,23,0,@|52,23,0,A|54,22,0,@|52,22,0,A|54,21,0,D|52,21,0,A|54,20,0,@|52,20,0,@|54,19,0,@|52,19,1,B|54,18,0,A|52,18,0,A|54,17,0,@|52,17,0,A|54,16,0,@|52,16,0,A|54,15,0,@|52,15,0,A|54,14,0,@|52,14,0,A|54,13,0,@|52,13,0,A|54,12,0,@|52,12,0,A|54,11,0,@|52,11,0,A|54,10,0,@|52,10,0,A|54,9,0,@|52,9,0,A|54,8,0,@|52,8,0,A|54,7,0,@|52,7,0,A|54,6,0,@|52,6,0,A|54,5,0,@|52,5,0,A|54,4,0,@|52,4,0,A|54,3,0,@|52,3,0,A|54,2,0,@|52,2,0,A|54,1,0,A|52,1,0,A|54,0,0,J|52,0,0,J|58,48,0,@|58,47,0,@|58,46,0,@|58,46,0,|56,46,0,@|58,45,0,@|56,45,0,@|58,44,0,@|56,44,0,@|58,43,0,@|56,43,0,@|58,42,0,@|56,42,0,@|58,41,0,@|56,41,0,@|58,40,0,@|56,40,0,@|58,39,0,@|56,39,0,@|58,38,0,@|56,38,0,@|58,37,0,@|56,37,0,@|58,36,0,@|56,36,0,@|58,35,0,@|56,35,0,@|58,34,0,A|56,34,0,A|58,33,0,@|56,33,0,@|58,32,0,@|56,32,0,@|58,31,0,A|56,31,0,A|58,30,0,@|58,30,0,A|56,30,0,@|58,29,0,@|58,29,0,A|56,29,0,@|58,28,0,@|58,28,0,A|56,28,0,@|58,27,0,@|58,27,0,A|56,27,0,@|58,26,0,@|58,26,0,A|56,26,0,@|56,26,0,A|58,25,0,@|58,25,0,A|56,25,0,@|58,24,0,@|58,24,0,A|56,24,0,@|58,23,0,@|58,23,0,A|56,23,0,@|58,22,0,@|58,22,0,A|56,22,0,@|58,21,0,A|56,21,0,A|58,20,0,@|56,20,0,@|58,19,0,@|56,19,0,@|58,18,0,A|56,18,0,A|58,17,0,@|56,17,0,@|58,16,0,@|56,16,0,@|58,15,0,@|56,15,0,@|58,14,0,@|56,14,0,@|58,13,0,@|56,13,0,@|58,12,0,@|56,12,0,@|58,11,0,@|56,11,0,@|58,10,0,@|56,10,0,@|58,9,0,@|56,9,0,@|58,8,0,@|56,8,0,@|58,7,0,@|56,7,0,@|58,6,0,@|58,6,0,|56,6,0,@|58,5,0,@|56,5,0,@|58,4,0,@|56,4,0,@|58,3,0,@|56,3,0,@|58,2,0,@|56,2,0,@|58,1,0,A|56,1,0,A|58,0,0,J|56,0,0,J|46,41,0,@|46,41,0,A|46,40,0,@|46,40,0,A|46,39,0,@|46,39,0,A|46,38,0,@|46,38,0,A|46,37,0,@|46,37,0,A|46,36,0,@|46,36,0,A|46,35,0,@|46,35,0,A|46,34,0,A|46,33,0,@|44,33,0,@|46,32,0,@|44,32,0,@|46,31,0,@|46,31,0,D|44,31,0,@|44,31,0,A|46,30,0,@|44,30,0,@|46,29,0,@|46,28,0,@|46,27,0,@|46,26,0,@|46,25,0,@|46,24,0,@|46,23,0,@|46,22,0,@|46,21,0,@|46,21,0,D|46,20,0,@|46,19,0,@|46,18,0,A|46,17,0,@|46,17,3,S|46,16,0,@|46,15,0,@|46,14,0,@|46,14,3,S|46,13,0,@|46,13,3,S|46,12,0,@|46,11,0,@|46,10,0,@|46,9,0,@|46,8,0,A|46,7,0,J|40,34,0,B|40,33,0,@|43,33,0,@|36,34,0,A|36,33,0,A|50,33,0,@|50,32,0,@|50,31,0,@|50,31,0,A|48,31,0,@|50,30,0,@|48,30,0,@|50,29,0,@|48,29,0,@|48,28,0,@|50,26,3,|50,27,0,@|48,27,0,@|50,26,0,@|48,26,0,@|50,25,0,@|48,25,0,@|50,23,0,@|48,23,0,@|50,22,0,@|48,22,0,@|50,21,0,@|50,21,0,A|48,21,0,@|50,20,0,@|48,20,0,@|50,19,0,@|48,19,0,@|50,18,0,A|48,18,0,A|50,17,0,@|48,17,0,@|48,17,2,S|50,16,0,@|50,16,3,S|48,16,0,@|50,15,0,@|50,15,3,S|48,15,0,@|50,14,0,@|48,14,0,@|50,13,0,@|48,13,0,@|50,12,0,@|48,12,0,@|50,11,0,@|50,11,0,A|48,11,0,@|48,11,0,A|50,10,0,@|48,10,0,@|50,9,0,@|48,9,0,@|50,8,0,A|48,8,0,A|50,7,0,J|48,7,0,J|8,33,0,A|8,34,1,D|9,36,0,@|8,35,0,A|10,36,0,@|11,36,0,A|12,36,0,@|13,36,0,@|14,36,0,@|15,36,0,@|16,36,0,@|17,36,0,@|18,36,0,@|19,36,0,A|20,36,0,@|21,36,0,@|22,36,0,@|22,36,2,x|23,36,0,@|24,36,0,@|25,36,2,G|25,36,0,@|26,36,0,A|9,30,0,@|9,29,0,@|9,28,0,@|10,28,0,[|10,28,0,@|10,28,3,G|11,28,0,A|12,28,0,@|13,28,0,@|14,28,0,@|15,28,0,@|16,28,0,@|17,28,0,@|18,29,0,@|19,30,0,A|20,30,0,@|21,30,0,@|22,30,0,@|24,29,0,@|23,30,0,@|25,29,0,@|26,29,0,@|27,29,0,@|28,29,0,@|29,30,0,@|29,30,3,B|30,31,0,@|30,31,0,A|31,31,0,@|31,31,0,A|12,31,0,@|12,30,0,@|10,29,0,[|10,29,0,@|13,30,0,@|14,30,0,@|15,30,0,@|16,30,0,@|17,31,0,@|25,31,0,@|26,31,0,@|27,31,0,@|90,24,0,@|92,23,0,@|91,24,0,@|92,22,0,A|92,21,0,@|90,21,0,@|92,20,0,@|90,20,0,@|92,19,0,@|90,19,0,@|92,18,0,@|90,18,0,@|92,17,0,@|90,17,0,@|92,16,0,@|90,16,0,@|92,15,0,@|90,15,0,@|92,14,0,@|90,14,0,@|92,13,0,@|90,13,0,@|92,12,0,A|90,12,0,A|92,11,0,J|90,11,0,J|86,21,0,@|86,21,0,~|86,20,0,@|88,19,0,@|86,19,0,@|88,18,0,@|86,18,0,@|88,17,0,@|86,17,0,@|88,16,0,@|86,16,0,@|88,15,0,@|86,15,0,@|88,14,0,@|86,14,0,@|88,13,0,@|86,13,0,@|86,13,0,~|88,12,0,A|86,12,0,A|88,11,0,J|86,11,0,J|78,21,0,A|78,20,0,@|80,19,0,@|78,19,0,@|80,18,0,A|78,18,0,A|80,17,0,J|78,17,0,J|84,19,3,B|84,18,0,A|84,17,0,J|82,17,0,J|72,19,0,@|72,18,0,A|72,17,0,J|70,17,0,J|105,22,0,A|107,21,0,J|106,22,0,A|98,19,0,@|98,18,0,A|100,17,0,b|98,17,0,J|97,14,0,A|97,13,0,A|97,12,0,A|97,11,0,J|94,15,0,@|94,14,0,@|96,13,0,@|94,13,0,@|94,13,0,~|96,12,0,A|94,12,0,A|96,11,0,J|94,11,0,J|27,35,2,G|23,37,2,G|53,30,1,|50,29,3,|50,22,3,|42,24,0,|42,28,0,|4,26,0,J|5,26,0,J|6,26,0,J|7,26,0,J|49,24,3,|50,24,0,@|50,28,0,@|50,28,0,A|50,24,0,A|48,28,1,}|48,24,0,@|48,24,1,}|48,21,0,A|48,31,0,A|44,26,1,|32,35,0,J|33,35,0,J|34,35,0,J|32,17,0,J|33,17,0,J|34,17,0,J|33,18,0,A|33,34,0,A|37,35,0,@|37,36,0,@|37,37,0,@|37,38,0,@|37,39,0,@|37,40,0,@|37,41,0,@|37,42,0,@|37,43,0,@|38,35,0,@|38,36,0,@|38,37,0,@|38,38,0,@|38,39,0,@|38,40,0,@|38,41,0,@|38,42,0,@|38,43,0,@|39,35,0,@|39,36,0,@|39,37,0,@|39,38,0,@|39,39,0,@|39,40,0,@|39,41,0,@|39,42,0,@|39,43,0,@|40,35,0,@|40,36,0,@|40,37,0,@|40,38,0,@|40,39,0,@|40,40,0,@|40,41,0,@|40,42,0,@|40,43,0,@|41,35,0,@|41,36,0,@|41,37,0,@|41,38,0,@|41,39,0,@|41,40,0,@|41,41,0,@|41,42,0,@|41,43,0,@|42,35,0,@|42,36,0,@|42,37,0,@|42,38,0,@|42,39,0,@|42,40,0,@|42,41,0,@|42,42,0,@|42,43,0,@|43,35,0,@|43,36,0,@|43,37,0,@|43,38,0,@|43,39,0,@|43,40,0,@|43,41,0,@|43,42,0,@|43,43,0,@|44,35,0,@|44,36,0,@|44,37,0,@|44,38,0,@|44,39,0,@|44,40,0,@|44,41,0,@|44,42,0,@|44,43,0,@|45,35,0,@|45,36,0,@|45,37,0,@|45,38,0,@|45,39,0,@|45,40,0,@|45,41,0,@|45,42,0,@|45,43,0,@|44,45,0,D|43,45,2,|45,45,2,|44,44,0,@|37,42,0,L|48,41,0,D|46,42,0,A|37,41,0,A|38,41,0,A|40,41,0,A|41,41,0,A|42,41,0,A|42,34,0,A|42,35,0,A|42,36,0,A|42,37,0,A|42,38,0,A|42,39,0,A|42,40,0,A|42,42,0,A|42,43,0,A|45,41,0,A|44,34,0,D|44,41,0,D|43,43,1,G|43,35,0,P|45,35,0,P|41,35,3,j|41,37,3,j|41,38,3,j|41,40,3,j|37,40,1,j|37,38,1,j|37,37,1,j|37,35,1,j|41,36,3,k|41,39,3,k|37,39,1,k|37,36,1,k|32,20,1,G|32,33,1,G|39,41,0,D|43,43,0,{|32,20,0,{|35,20,0,t|35,19,0,t|43,36,0,|45,36,0,|37,32,0,E|43,34,0,B|43,41,0,B|32,23,0,|42,27,3,|40,21,1,|34,20,0,|37,15,3,|30,25,2,|25,23,0,|23,25,2,|18,21,1,|20,17,3,|32,29,2,|40,31,1,|27,17,2,|40,25,2,|41,14,3,|39,10,0,|10,21,1,|8,14,0,|16,14,0,|61,32,2,|61,20,0,|55,32,2,|55,25,0,|55,20,0,|47,42,2,|47,30,0,|47,22,2,|50,14,1,|37,38,3,|20,35,3,|25,29,2,|10,31,1,|18,31,1,|27,35,0,|16,38,2,|8,38,2,|34,32,2,|44,9,2,|70,32,2,|76,30,0,|80,32,2,|90,23,2,|80,20,0,|86,17,3,|74,22,2,|70,20,0,|95,18,1,|98,21,0,|100,23,2,|90,29,0,|98,31,2,|100,29,0,|95,34,1,|86,35,3,|62,30,0,|62,22,2,|58,35,2,|59,27,3,|59,26,3,|56,27,2,|58,17,0,|47,38,3,|46,33,0,|46,19,2,|48,10,0,|40,42,2,|43,38,3,|43,43,3,|49,12,0,|48,12,0,|57,30,2,|56,30,2,G|47,36,1,G|47,40,1,G|47,40,0,|47,36,0,|50,36,3,|50,39,3,|30,26,0,@|32,26,3,G|32,26,0,|30,26,0,m|74,23,0,@|74,22,1,|74,23,0,m|60,18,2,B|60,34,0,B|41,9,0,|42,9,0,|43,9,0,|44,9,0,|45,9,0,|46,9,0,|41,10,0,|42,10,0,|43,10,0,|44,10,0,|45,10,0,|46,10,0,|41,11,0,|42,11,0,|43,11,0,|44,11,0,|45,11,0,|46,11,0,|37,12,0,|38,12,0,|39,12,0,|41,12,0,|42,12,0,|43,12,0,|44,12,0,|45,12,0,|46,12,0,|47,12,0,|48,12,0,|49,12,0,|50,12,0,|37,13,0,|38,13,0,|39,13,0,|41,13,0,|42,13,0,|43,13,0,|44,13,0,|45,13,0,|46,13,0,|47,13,0,|48,13,0,|49,13,0,|50,13,0,|86,13,0,|87,13,0,|88,13,0,|89,13,0,|90,13,0,|91,13,0,|92,13,0,|93,13,0,|94,13,0,|95,13,0,|96,13,0,|20,14,0,|21,14,0,|37,14,0,|38,14,0,|39,14,0,|41,14,0,|42,14,0,|43,14,0,|44,14,0,|45,14,0,|46,14,0,|47,14,0,|48,14,0,|49,14,0,|50,14,0,|86,14,0,|87,14,0,|88,14,0,|89,14,0,|90,14,0,|91,14,0,|92,14,0,|93,14,0,|94,14,0,|95,14,0,|96,14,0,|20,15,0,|21,15,0,|22,15,0,|23,15,0,|37,15,0,|38,15,0,|39,15,0,|41,15,0,|42,15,0,|43,15,0,|44,15,0,|45,15,0,|46,15,0,|47,15,0,|48,15,0,|49,15,0,|50,15,0,|86,15,0,|87,15,0,|88,15,0,|89,15,0,|90,15,0,|91,15,0,|92,15,0,|93,15,0,|94,15,0,|95,15,0,|96,15,0,|20,16,0,|21,16,0,|22,16,0,|23,16,0,|24,16,0,|25,16,0,|37,16,0,|38,16,0,|39,16,0,|41,16,0,|42,16,0,|43,16,0,|44,16,0,|45,16,0,|46,16,0,|47,16,0,|48,16,0,|49,16,0,|50,16,0,|86,16,0,|87,16,0,|88,16,0,|89,16,0,|90,16,0,|91,16,0,|92,16,0,|93,16,0,|94,16,0,|95,16,0,|96,16,0,|20,17,0,|21,17,0,|22,17,0,|23,17,0,|24,17,0,|25,17,0,|26,17,0,|27,17,0,|37,17,0,|38,17,0,|39,17,0,|41,17,0,|42,17,0,|43,17,0,|44,17,0,|45,17,0,|46,17,0,|47,17,0,|48,17,0,|49,17,0,|50,17,0,|86,17,0,|87,17,0,|88,17,0,|89,17,0,|90,17,0,|91,17,0,|92,17,0,|93,17,0,|94,17,0,|95,17,0,|96,17,0,|20,18,0,|21,18,0,|22,18,0,|23,18,0,|24,18,0,|25,18,0,|26,18,0,|27,18,0,|28,18,0,|29,18,0,|30,18,0,|86,18,0,|87,18,0,|88,18,0,|89,18,0,|90,18,0,|91,18,0,|92,18,0,|93,18,0,|94,18,0,|95,18,0,|20,19,0,|21,19,0,|22,19,0,|23,19,0,|24,19,0,|25,19,0,|26,19,0,|27,19,0,|28,19,0,|29,19,0,|30,19,0,|37,19,0,|38,19,0,|39,19,0,|40,19,0,|41,19,0,|42,19,0,|43,19,0,|44,19,0,|45,19,0,|46,19,0,|47,19,0,|48,19,0,|49,19,0,|50,19,0,|53,19,0,|54,19,0,|55,19,0,|56,19,0,|57,19,0,|58,19,0,|59,19,0,|60,19,0,|61,19,0,|62,19,0,|63,19,0,|64,19,0,|67,19,0,|68,19,0,|69,19,0,|70,19,0,|71,19,0,|72,19,0,|73,19,0,|74,19,0,|75,19,0,|76,19,0,|77,19,0,|78,19,0,|79,19,0,|80,19,0,|81,19,0,|82,19,0,|83,19,0,|86,19,0,|87,19,0,|88,19,0,|89,19,0,|90,19,0,|91,19,0,|92,19,0,|93,19,0,|94,19,0,|95,19,0,|20,20,0,|21,20,0,|22,20,0,|23,20,0,|24,20,0,|25,20,0,|26,20,0,|27,20,0,|28,20,0,|29,20,0,|30,20,0,|37,20,0,|38,20,0,|39,20,0,|40,20,0,|41,20,0,|42,20,0,|43,20,0,|44,20,0,|45,20,0,|46,20,0,|47,20,0,|48,20,0,|49,20,0,|50,20,0,|52,20,0,|53,20,0,|54,20,0,|55,20,0,|56,20,0,|57,20,0,|58,20,0,|59,20,0,|60,20,0,|61,20,0,|62,20,0,|63,20,0,|64,20,0,|66,20,0,|67,20,0,|68,20,0,|69,20,0,|70,20,0,|71,20,0,|72,20,0,|73,20,0,|74,20,0,|75,20,0,|76,20,0,|77,20,0,|78,20,0,|79,20,0,|80,20,0,|81,20,0,|82,20,0,|83,20,0,|84,20,0,|86,20,0,|87,20,0,|88,20,0,|89,20,0,|90,20,0,|91,20,0,|92,20,0,|93,20,0,|94,20,0,|95,20,0,|20,21,0,|21,21,0,|22,21,0,|23,21,0,|24,21,0,|25,21,0,|26,21,0,|27,21,0,|28,21,0,|37,21,0,|38,21,0,|39,21,0,|40,21,0,|86,21,0,|87,21,0,|88,21,0,|89,21,0,|90,21,0,|91,21,0,|92,21,0,|93,21,0,|94,21,0,|95,21,0,|20,22,0,|21,22,0,|22,22,0,|23,22,0,|24,22,0,|25,22,0,|26,22,0,|27,22,0,|28,22,0,|30,22,0,|31,22,0,|32,22,0,|33,22,0,|34,22,0,|35,22,0,|37,22,0,|38,22,0,|39,22,0,|40,22,0,|42,22,0,|43,22,0,|44,22,0,|45,22,0,|46,22,0,|47,22,0,|48,22,0,|49,22,0,|50,22,0,|53,22,0,|54,22,0,|55,22,0,|56,22,0,|57,22,0,|20,23,0,|21,23,0,|22,23,0,|23,23,0,|24,23,0,|25,23,0,|26,23,0,|27,23,0,|28,23,0,|30,23,0,|31,23,0,|32,23,0,|33,23,0,|34,23,0,|35,23,0,|37,23,0,|38,23,0,|39,23,0,|40,23,0,|42,23,0,|43,23,0,|44,23,0,|45,23,0,|46,23,0,|47,23,0,|48,23,0,|49,23,0,|50,23,0,|53,23,0,|54,23,0,|55,23,0,|56,23,0,|57,23,0,|42,24,0,|43,24,0,|44,24,0,|45,24,0,|46,24,0,|47,24,0,|48,24,0,|49,24,0,|53,24,0,|54,24,0,|55,24,0,|56,24,0,|57,24,0,|42,25,0,|43,25,0,|44,25,0,|45,25,0,|46,25,0,|47,25,0,|48,25,0,|49,25,0,|50,25,0,|53,25,0,|54,25,0,|55,25,0,|56,25,0,|57,25,0,|42,26,0,|43,26,0,|44,26,0,|45,26,0,|46,26,0,|47,26,0,|48,26,0,|49,26,0,|50,26,0,|42,27,0,|43,27,0,|44,27,0,|45,27,0,|46,27,0,|47,27,0,|48,27,0,|49,27,0,|50,27,0,|53,27,0,|54,27,0,|55,27,0,|56,27,0,|57,27,0,|42,28,0,|43,28,0,|44,28,0,|45,28,0,|46,28,0,|47,28,0,|48,28,0,|49,28,0,|53,28,0,|54,28,0,|55,28,0,|56,28,0,|57,28,0,|20,29,0,|21,29,0,|22,29,0,|23,29,0,|24,29,0,|25,29,0,|26,29,0,|27,29,0,|28,29,0,|30,29,0,|31,29,0,|32,29,0,|33,29,0,|34,29,0,|35,29,0,|37,29,0,|38,29,0,|39,29,0,|40,29,0,|42,29,0,|43,29,0,|44,29,0,|45,29,0,|46,29,0,|47,29,0,|48,29,0,|49,29,0,|50,29,0,|53,29,0,|54,29,0,|55,29,0,|56,29,0,|57,29,0,|20,30,0,|21,30,0,|22,30,0,|23,30,0,|24,30,0,|25,30,0,|26,30,0,|27,30,0,|28,30,0,|30,30,0,|31,30,0,|32,30,0,|33,30,0,|34,30,0,|35,30,0,|37,30,0,|38,30,0,|39,30,0,|40,30,0,|42,30,0,|43,30,0,|44,30,0,|45,30,0,|46,30,0,|47,30,0,|48,30,0,|49,30,0,|50,30,0,|53,30,0,|54,30,0,|55,30,0,|56,30,0,|57,30,0,|20,31,0,|21,31,0,|22,31,0,|23,31,0,|24,31,0,|25,31,0,|26,31,0,|27,31,0,|28,31,0,|37,31,0,|38,31,0,|39,31,0,|40,31,0,|86,31,0,|87,31,0,|88,31,0,|89,31,0,|90,31,0,|91,31,0,|92,31,0,|93,31,0,|94,31,0,|95,31,0,|20,32,0,|21,32,0,|22,32,0,|23,32,0,|24,32,0,|25,32,0,|26,32,0,|27,32,0,|28,32,0,|29,32,0,|30,32,0,|37,32,0,|38,32,0,|39,32,0,|40,32,0,|41,32,0,|42,32,0,|43,32,0,|44,32,0,|45,32,0,|46,32,0,|47,32,0,|48,32,0,|49,32,0,|50,32,0,|52,32,0,|53,32,0,|54,32,0,|55,32,0,|56,32,0,|57,32,0,|58,32,0,|59,32,0,|60,32,0,|61,32,0,|62,32,0,|63,32,0,|64,32,0,|66,32,0,|67,32,0,|68,32,0,|69,32,0,|70,32,0,|71,32,0,|72,32,0,|73,32,0,|74,32,0,|75,32,0,|76,32,0,|77,32,0,|78,32,0,|79,32,0,|80,32,0,|81,32,0,|82,32,0,|83,32,0,|84,32,0,|86,32,0,|87,32,0,|88,32,0,|89,32,0,|90,32,0,|91,32,0,|92,32,0,|93,32,0,|94,32,0,|95,32,0,|20,33,0,|21,33,0,|22,33,0,|23,33,0,|24,33,0,|25,33,0,|26,33,0,|27,33,0,|28,33,0,|29,33,0,|30,33,0,|37,33,0,|38,33,0,|39,33,0,|40,33,0,|41,33,0,|42,33,0,|43,33,0,|44,33,0,|45,33,0,|46,33,0,|47,33,0,|48,33,0,|49,33,0,|50,33,0,|53,33,0,|54,33,0,|55,33,0,|56,33,0,|57,33,0,|58,33,0,|59,33,0,|60,33,0,|61,33,0,|62,33,0,|63,33,0,|64,33,0,|67,33,0,|68,33,0,|69,33,0,|70,33,0,|71,33,0,|72,33,0,|73,33,0,|74,33,0,|75,33,0,|76,33,0,|77,33,0,|78,33,0,|79,33,0,|80,33,0,|81,33,0,|82,33,0,|83,33,0,|86,33,0,|87,33,0,|88,33,0,|89,33,0,|90,33,0,|91,33,0,|92,33,0,|93,33,0,|94,33,0,|95,33,0,|20,34,0,|21,34,0,|22,34,0,|23,34,0,|24,34,0,|25,34,0,|26,34,0,|27,34,0,|28,34,0,|29,34,0,|30,34,0,|86,34,0,|87,34,0,|88,34,0,|89,34,0,|90,34,0,|91,34,0,|92,34,0,|93,34,0,|94,34,0,|95,34,0,|20,35,0,|21,35,0,|22,35,0,|23,35,0,|24,35,0,|25,35,0,|26,35,0,|27,35,0,|37,35,0,|38,35,0,|39,35,0,|40,35,0,|41,35,0,|43,35,0,|44,35,0,|45,35,0,|47,35,0,|48,35,0,|49,35,0,|50,35,0,|86,35,0,|87,35,0,|88,35,0,|89,35,0,|90,35,0,|91,35,0,|92,35,0,|93,35,0,|94,35,0,|95,35,0,|96,35,0,|20,36,0,|21,36,0,|22,36,0,|23,36,0,|24,36,0,|25,36,0,|37,36,0,|38,36,0,|39,36,0,|40,36,0,|41,36,0,|43,36,0,|44,36,0,|45,36,0,|47,36,0,|48,36,0,|49,36,0,|50,36,0,|86,36,0,|87,36,0,|88,36,0,|89,36,0,|90,36,0,|91,36,0,|92,36,0,|93,36,0,|94,36,0,|95,36,0,|96,36,0,|20,37,0,|21,37,0,|22,37,0,|23,37,0,|37,37,0,|38,37,0,|39,37,0,|40,37,0,|41,37,0,|43,37,0,|44,37,0,|45,37,0,|47,37,0,|48,37,0,|49,37,0,|50,37,0,|86,37,0,|87,37,0,|88,37,0,|89,37,0,|90,37,0,|91,37,0,|92,37,0,|93,37,0,|94,37,0,|95,37,0,|96,37,0,|20,38,0,|21,38,0,|37,38,0,|38,38,0,|39,38,0,|40,38,0,|41,38,0,|43,38,0,|44,38,0,|45,38,0,|47,38,0,|48,38,0,|49,38,0,|50,38,0,|86,38,0,|87,38,0,|88,38,0,|89,38,0,|90,38,0,|91,38,0,|92,38,0,|93,38,0,|94,38,0,|95,38,0,|96,38,0,|37,39,0,|38,39,0,|39,39,0,|40,39,0,|41,39,0,|43,39,0,|44,39,0,|45,39,0,|47,39,0,|48,39,0,|49,39,0,|50,39,0,|86,39,0,|87,39,0,|88,39,0,|89,39,0,|90,39,0,|91,39,0,|92,39,0,|93,39,0,|94,39,0,|95,39,0,|96,39,0,|37,40,0,|38,40,0,|39,40,0,|40,40,0,|41,40,0,|43,40,0,|44,40,0,|45,40,0,|47,40,0,|48,40,0,|49,40,0,|50,40,0,|43,42,0,|44,42,0,|45,42,0,|43,43,0,|44,43,0,|45,43,0,|44,44,0,</bigString>
+		<bigString>41,17,2,?|41,16,2,@|41,11,2,?|37,17,2,A|28,22,0,B|28,21,0,B|37,16,2,A|37,15,2,@|10,23,0,C|16,23,0,C|15,21,0,C|10,21,0,C|10,19,0,C|15,14,0,D|35,33,2,E|10,33,0,C|15,29,0,C|16,29,0,C|10,32,0,C|15,38,0,D|35,32,2,F|90,35,0,G|95,33,0,B|76,29,0,H|74,29,0,I|76,23,0,J|76,22,0,J|76,30,0,K|10,28,0,C|10,29,0,C|43,43,0,F|32,20,0,F|35,20,0,E|35,19,0,E|47,40,0,L|47,36,0,L|32,26,0,I|37,25,0,M|37,26,0,M|37,27,0,M|38,25,0,M|38,26,0,M|38,27,0,M|39,25,0,M|39,26,0,M|39,27,0,M|37,24,0,M|37,24,0,N|36,24,0,N|35,24,0,N|34,24,0,N|33,24,2,O|32,24,0,N|32,25,0,M|32,26,0,M|33,26,0,M|34,26,0,M|35,26,0,M|35,27,0,M|35,28,0,N|36,28,0,N|36,29,1,P|37,29,0,M|38,29,0,M|39,29,0,M|40,29,0,M|40,28,0,M|40,28,0,N|41,28,0,M|41,28,0,N|41,27,0,M|41,27,0,N|41,26,0,M|41,26,1,P|41,25,0,M|41,25,0,N|41,24,0,M|41,24,0,N|41,23,0,M|41,23,0,N|41,22,0,M|41,22,0,N|41,21,0,M|41,21,0,N|41,20,0,M|41,19,0,M|41,18,0,N|41,17,0,M|41,16,0,M|41,15,0,M|41,14,0,M|41,13,0,M|41,12,0,M|41,11,0,M|41,10,0,M|41,9,0,M|41,8,0,N|41,7,0,Q|32,23,0,M|31,23,0,M|31,22,0,M|31,21,0,M|31,21,0,N|31,20,0,M|31,20,0,N|31,19,0,M|31,19,0,N|31,18,0,N|31,17,0,N|32,22,0,M|33,22,0,M|34,22,0,M|34,21,0,M|34,21,0,N|34,20,0,M|34,19,0,M|34,18,0,O|33,21,0,M|33,21,0,P|33,25,0,M|33,23,0,M|34,25,0,M|34,23,0,M|35,25,0,M|35,23,0,M|36,23,1,P|36,22,0,N|37,22,0,M|38,22,0,M|38,23,0,M|39,23,0,M|39,22,0,M|39,21,0,M|39,20,0,M|38,20,0,M|37,20,0,M|36,20,0,N|36,19,0,N|36,18,0,N|37,18,0,N|38,18,0,P|38,17,0,M|38,16,0,M|38,15,0,M|38,14,0,M|38,13,0,M|38,12,0,M|38,11,0,M|38,11,0,N|38,10,0,M|38,9,0,M|38,8,0,N|38,7,0,Q|37,17,0,M|36,17,0,N|36,16,0,N|35,16,0,Q|35,15,0,Q|35,14,0,Q|36,14,0,N|36,13,0,N|36,12,0,N|36,11,0,N|36,10,0,N|36,9,0,N|36,8,0,N|36,7,0,Q|35,13,0,Q|36,15,0,N|37,19,0,M|38,19,0,M|39,19,0,M|38,21,0,M|37,21,0,M|36,21,0,N|37,23,0,M|38,24,0,M|38,24,0,N|39,24,0,M|39,24,0,N|40,25,0,M|40,26,0,M|40,27,0,M|39,28,0,M|39,28,0,N|38,28,0,M|38,28,0,N|37,28,0,M|37,28,0,N|36,27,0,N|36,26,0,N|36,25,0,N|31,24,0,P|30,24,0,N|29,24,0,N|28,24,0,N|27,24,0,N|26,24,0,N|25,24,0,N|24,24,0,P|23,24,0,N|22,24,0,N|21,24,0,N|20,24,0,N|19,24,3,O|19,23,1,P|19,22,0,N|19,21,0,N|19,20,0,N|19,19,0,N|19,18,0,N|19,17,0,N|19,16,0,N|19,15,0,N|19,14,0,N|19,13,0,N|19,12,0,N|19,11,0,N|20,25,0,M|20,26,0,M|20,27,0,M|21,27,0,M|22,27,0,M|22,26,0,M|23,26,0,M|24,26,0,M|25,26,0,M|26,26,0,M|26,26,0,N|27,26,0,M|28,26,0,M|29,26,0,M|30,27,0,M|31,27,0,M|31,28,0,P|32,28,0,N|33,28,0,O|33,29,0,M|34,29,0,M|34,30,0,M|35,30,0,M|35,30,0,R|35,31,0,M|35,31,0,N|36,31,0,N|37,31,0,M|38,31,0,M|39,31,0,M|40,31,0,M|41,31,0,M|41,31,0,N|41,30,0,M|41,30,0,N|43,21,0,M|43,21,0,N|43,20,0,M|43,19,0,M|43,18,0,N|43,17,0,M|43,16,0,M|43,15,0,M|43,14,0,M|43,13,0,M|43,12,0,M|43,11,0,M|43,10,0,M|43,10,0,S|43,9,0,M|43,8,0,N|43,7,0,Q|21,26,0,M|20,23,0,M|21,25,0,M|21,23,0,M|21,22,0,M|22,22,0,M|23,22,0,M|24,22,0,M|25,22,0,M|25,21,0,M|25,20,0,M|25,19,0,M|25,18,0,M|25,17,0,M|25,16,0,M|25,15,0,N|25,14,0,Q|24,21,0,M|23,21,0,M|23,20,0,M|22,20,0,M|21,20,0,M|21,19,0,M|21,18,0,M|21,17,0,M|21,16,0,M|21,15,0,M|21,14,0,M|21,13,0,N|21,12,0,Q|22,19,0,M|23,19,0,M|23,18,0,M|23,17,0,M|23,16,0,M|23,15,0,M|23,14,0,N|23,13,0,Q|22,21,0,M|21,21,0,M|22,25,0,M|22,23,0,M|23,25,0,M|23,23,0,M|24,25,0,M|24,23,0,M|25,25,0,M|25,23,0,M|26,25,0,M|26,25,0,N|26,23,0,M|27,25,0,M|27,23,0,M|27,22,0,M|28,22,0,M|29,22,0,M|29,22,3,O|29,21,0,M|29,21,0,N|29,20,0,M|28,20,0,M|27,20,0,M|27,19,0,M|27,18,0,M|28,18,0,M|29,18,0,M|29,17,0,N|29,16,0,Q|28,16,0,N|27,16,0,N|27,15,0,Q|28,17,0,N|27,17,0,M|28,19,0,M|29,19,0,M|28,21,0,M|27,21,0,M|28,25,0,M|28,23,0,M|29,25,0,M|29,23,0,M|29,23,1,P|30,25,0,M|31,25,0,M|32,27,0,M|31,26,0,M|33,27,0,M|34,27,0,M|35,29,0,M|34,28,0,N|36,30,0,N|37,30,0,M|38,30,0,M|39,30,0,M|41,29,0,M|41,29,0,N|40,30,0,M|40,24,0,M|40,24,0,N|40,23,0,M|40,22,0,M|42,21,0,M|42,21,0,N|40,21,0,M|42,20,0,M|40,20,0,M|42,19,0,M|40,19,0,M|42,18,0,P|40,18,0,N|42,17,0,M|40,17,0,M|40,17,0,N|42,16,0,M|40,16,0,M|40,16,0,N|42,15,0,M|40,15,0,M|40,15,1,P|42,14,0,M|40,14,0,M|40,14,0,N|42,13,0,M|40,13,0,M|40,13,0,N|42,12,0,M|40,12,0,M|40,12,0,N|42,11,0,M|40,11,0,M|40,11,0,N|42,10,0,M|40,10,0,M|40,10,0,N|42,9,0,M|40,9,0,M|40,9,1,P|42,8,0,N|40,8,0,N|42,7,0,Q|40,7,0,Q|30,23,0,M|30,22,0,M|32,21,0,M|32,21,0,N|30,21,0,M|30,21,0,N|32,20,0,M|30,20,0,M|32,19,0,M|30,19,0,M|32,18,0,N|30,18,0,M|30,17,0,N|35,22,0,M|35,22,0,R|35,21,0,M|35,21,0,N|35,20,0,M|33,20,0,M|35,19,0,M|33,19,0,M|35,18,0,N|35,17,0,Q|39,18,2,O|39,17,0,M|39,16,0,M|37,16,0,M|39,15,0,M|37,15,0,M|39,14,0,M|37,14,0,M|39,13,0,M|37,13,0,M|39,12,0,M|37,12,0,M|39,11,0,M|39,11,0,N|37,11,0,M|37,11,0,N|39,10,0,M|37,10,0,M|39,9,0,M|37,9,0,M|39,8,0,N|37,8,0,N|39,7,0,Q|37,7,0,Q|35,12,0,Q|35,11,0,Q|35,10,0,Q|35,9,0,Q|35,8,0,Q|35,7,0,Q|19,25,0,N|18,25,0,M|18,25,0,T|17,25,0,M|17,25,0,T|16,25,0,M|15,25,0,M|14,25,0,M|13,25,0,M|12,25,0,M|11,25,0,N|10,25,0,M|9,25,0,M|8,25,0,N|8,23,1,P|9,23,0,M|10,23,0,M|11,23,3,O|12,23,0,M|13,23,0,M|14,23,0,M|15,23,0,M|16,23,0,M|17,23,0,M|17,22,0,M|17,21,0,M|16,21,0,M|15,21,0,M|14,21,0,M|13,21,0,M|12,21,0,M|11,21,0,N|10,21,0,M|9,21,0,M|8,21,0,N|8,19,0,N|9,19,0,M|10,19,0,M|11,19,0,N|12,19,0,M|13,19,0,M|14,19,0,M|15,19,0,M|16,19,0,M|17,19,0,M|17,19,0,U|17,18,0,M|17,17,0,M|17,17,0,T|16,17,0,M|15,17,0,M|14,17,0,M|13,17,0,M|12,17,0,M|11,17,0,N|10,17,0,N|9,17,0,N|8,17,0,N|4,15,0,N|5,15,0,N|6,15,0,N|7,15,0,N|8,15,0,N|9,15,0,M|10,15,0,M|11,15,2,O|12,15,0,N|13,15,0,N|14,15,0,N|15,15,0,N|16,15,0,N|17,15,0,P|17,14,0,M|17,13,0,M|16,13,0,M|15,13,0,M|14,13,0,M|13,13,0,M|12,13,0,M|11,13,0,M|10,13,0,M|9,13,0,M|8,13,0,M|7,13,0,M|6,13,0,M|5,13,0,M|4,13,0,N|3,13,0,N|0,12,0,Q|1,11,0,Q|2,11,0,Q|3,11,0,N|4,11,0,M|5,11,0,M|6,11,0,M|7,11,0,M|8,11,0,M|9,11,0,M|10,11,0,M|10,10,0,N|10,9,0,Q|9,10,0,N|8,10,0,N|8,9,0,Q|7,9,0,Q|6,9,0,Q|7,10,0,N|6,10,0,N|5,10,0,N|4,10,0,N|4,9,0,V|3,9,0,Q|2,9,0,V|1,9,0,Q|3,10,0,N|2,10,0,N|1,10,0,Q|1,12,0,Q|2,12,0,Q|3,12,0,N|4,12,0,M|5,12,0,M|6,12,0,M|7,12,0,M|8,12,0,M|9,12,0,M|10,12,0,M|11,12,0,M|12,12,0,M|12,11,0,M|13,11,0,M|14,11,0,M|15,11,0,M|16,11,0,M|17,11,0,N|17,10,0,N|15,9,0,Q|14,9,0,Q|13,9,0,Q|12,9,0,Q|16,10,0,N|15,10,0,N|14,10,0,N|13,10,0,N|12,10,0,N|13,12,0,M|14,12,0,M|15,12,0,M|16,12,0,M|17,12,0,M|16,14,0,M|15,14,0,M|14,14,0,M|13,14,0,M|12,14,0,M|11,14,0,M|10,14,0,M|9,14,0,M|8,14,0,M|7,14,0,M|6,14,0,M|5,14,0,M|4,14,0,N|8,16,0,N|9,16,0,M|10,16,0,M|11,16,0,N|12,16,0,M|13,16,0,M|14,16,0,M|15,16,0,M|16,16,0,M|17,16,0,M|16,18,0,M|15,18,0,M|14,18,0,M|13,18,0,M|12,18,0,M|11,18,0,N|10,18,0,M|9,18,0,M|8,18,1,P|8,20,0,N|9,20,0,M|10,20,0,M|11,20,0,N|12,20,0,M|13,20,0,M|14,20,0,M|15,20,0,M|16,20,0,M|17,20,0,M|16,22,0,M|15,22,0,M|14,22,0,M|13,22,0,M|12,22,0,M|11,22,1,P|10,22,0,M|9,22,0,M|8,22,0,N|3,39,0,N|0,40,0,Q|1,43,0,Q|2,43,2,V|3,43,0,Q|4,43,2,V|5,43,0,Q|6,43,0,Q|7,43,0,Q|8,43,0,Q|9,43,0,Q|10,43,0,Q|11,43,0,Q|12,43,0,Q|13,43,0,Q|14,43,0,Q|15,43,0,Q|17,42,0,N|19,41,0,N|21,40,0,Q|23,39,0,Q|25,38,0,Q|27,37,0,Q|29,36,0,Q|31,35,0,N|35,35,0,Q|35,36,0,Q|35,37,0,Q|35,38,0,Q|35,39,0,Q|35,40,0,Q|35,41,0,Q|35,42,0,Q|35,43,0,Q|35,44,0,Q|35,45,0,Q|36,45,0,Q|37,45,0,Q|38,45,0,Q|39,45,0,Q|40,45,0,Q|41,45,0,Q|42,45,0,Q|46,45,0,Q|47,45,0,Q|48,45,0,Q|49,45,0,Q|50,45,0,Q|51,45,0,Q|51,46,0,Q|51,47,0,Q|51,48,0,Q|51,49,0,Q|50,49,2,W|50,50,0,Q|50,52,0,Q|51,52,0,Q|52,52,0,Q|53,52,0,Q|54,52,0,Q|55,52,0,Q|56,52,0,Q|57,52,0,Q|58,52,0,Q|59,52,0,Q|60,52,0,Q|61,52,0,Q|62,52,0,Q|63,52,0,Q|64,52,0,Q|65,52,0,Q|65,51,0,N|65,50,0,N|65,49,0,N|65,48,0,N|65,47,0,N|65,46,0,N|65,45,0,N|65,44,0,N|65,43,0,N|65,42,0,N|65,41,0,N|65,40,0,N|65,39,0,N|65,38,0,N|65,37,0,N|65,36,0,N|65,35,0,N|65,34,0,N|65,33,0,N|65,32,1,P|65,31,0,N|65,30,0,N|65,29,0,N|65,28,0,N|65,27,0,N|65,26,3,O|65,25,0,N|65,24,0,N|65,23,0,N|65,22,0,N|65,21,0,N|65,20,1,P|65,19,0,N|65,18,0,N|65,17,0,N|65,16,0,N|65,15,0,N|65,14,0,N|65,13,0,N|65,12,0,N|65,11,0,N|65,10,0,N|65,9,0,N|65,8,0,N|65,7,0,N|65,6,0,N|65,5,0,N|65,4,0,N|65,3,0,N|65,2,0,N|65,1,0,N|65,0,0,Q|64,51,0,N|63,51,0,N|63,50,0,M|62,50,0,M|61,50,0,M|61,49,0,M|61,48,0,M|61,47,0,M|61,46,0,M|61,45,0,M|61,44,0,M|61,43,0,M|61,42,0,M|61,41,0,M|61,40,0,M|61,39,0,M|61,38,0,M|61,37,0,M|61,36,0,M|61,35,0,M|61,34,0,N|61,33,0,M|61,32,0,M|61,31,0,N|61,30,0,M|61,29,0,M|61,28,0,M|61,27,0,M|61,26,0,M|61,25,0,M|61,24,0,M|61,23,0,M|61,22,0,M|61,21,0,N|61,20,0,M|61,19,0,M|61,18,0,N|61,17,0,M|61,16,0,M|61,15,0,M|61,14,0,M|61,13,0,M|61,12,0,M|61,11,0,M|61,10,0,M|61,9,0,M|61,8,0,M|61,7,0,M|61,6,0,M|61,5,0,M|61,4,0,M|61,3,0,M|61,2,0,M|61,1,0,N|61,0,0,Q|62,49,0,M|63,49,0,M|63,48,0,M|63,47,0,M|63,46,0,M|63,45,0,M|63,44,0,M|63,43,0,M|63,42,0,M|63,41,0,M|63,40,0,M|63,39,0,M|63,38,0,M|63,37,0,M|63,36,0,M|63,35,0,M|63,34,0,N|63,33,0,M|63,32,0,M|63,31,0,N|63,30,0,M|63,29,0,M|63,28,0,M|63,27,0,M|63,26,0,M|63,25,0,M|63,24,0,M|63,23,0,M|63,22,0,M|63,21,0,N|63,20,0,M|63,19,0,M|63,18,0,N|63,17,0,M|63,16,0,M|63,15,0,M|63,14,0,M|63,13,0,M|63,12,0,M|63,11,0,M|63,10,0,M|63,9,0,M|63,8,0,M|63,7,0,M|63,6,0,M|63,5,0,M|63,4,0,M|63,3,0,M|63,2,0,M|63,1,0,N|63,0,0,Q|62,51,0,N|61,51,0,N|60,51,0,N|59,51,0,N|59,50,0,M|58,50,0,M|57,50,0,M|56,50,0,M|55,50,0,M|54,50,0,M|53,50,0,M|53,49,0,M|53,48,0,M|53,47,0,M|53,46,0,M|53,45,0,M|53,44,0,M|53,43,0,M|53,42,0,M|53,41,0,M|53,40,0,M|53,39,0,M|53,38,0,M|53,37,0,M|53,36,0,M|53,35,0,M|53,34,0,N|53,33,0,M|53,32,0,M|53,31,2,O|53,21,0,O|53,20,0,M|53,19,0,M|53,18,0,N|53,17,0,M|53,16,0,M|53,15,0,M|53,14,0,M|53,13,0,M|53,12,0,M|53,11,0,M|53,10,0,M|53,9,0,M|53,8,0,M|53,7,0,M|53,6,0,M|53,5,0,M|53,4,0,M|53,3,0,M|53,2,0,M|53,1,0,N|53,0,0,Q|54,49,0,M|55,49,0,M|55,48,0,M|56,48,0,M|57,48,0,M|57,47,0,M|57,46,0,M|57,45,0,M|57,45,0,T|57,44,0,M|57,43,0,M|57,42,0,M|57,41,0,M|57,40,0,M|57,39,0,M|57,38,0,M|57,37,0,M|57,36,0,M|57,36,0,T|57,35,0,M|57,34,0,P|57,33,0,M|57,32,0,M|57,21,0,N|57,20,0,M|57,19,0,M|57,18,0,P|57,17,0,M|57,16,0,M|57,16,0,T|57,15,0,M|57,14,0,M|57,13,0,M|57,12,0,M|57,11,0,M|57,10,0,M|57,9,0,M|57,8,0,M|57,7,0,M|57,7,0,T|57,6,0,M|57,5,0,M|57,4,0,M|57,3,0,M|57,2,0,M|57,1,0,N|57,0,0,Q|56,47,0,M|55,47,0,M|55,46,0,M|55,45,0,M|55,44,0,M|55,43,0,M|55,42,0,M|55,41,0,M|55,40,0,M|55,39,0,M|55,38,0,M|55,37,0,M|55,36,0,M|55,35,0,M|55,34,0,N|55,33,0,M|55,32,0,M|55,31,0,N|55,21,0,N|55,20,0,M|55,19,0,M|55,18,0,N|55,17,0,M|55,16,0,M|55,15,0,M|55,14,0,M|55,13,0,M|55,12,0,M|55,11,0,M|55,10,0,M|55,9,0,M|55,8,0,M|55,7,0,M|55,6,0,M|55,5,0,M|55,4,0,M|55,3,0,M|55,2,0,M|55,1,0,N|55,0,0,Q|56,49,0,M|57,49,0,M|58,49,0,M|59,49,0,M|59,48,0,M|59,47,0,M|59,46,0,M|59,46,0,X|59,45,0,M|59,44,0,M|59,43,0,M|59,42,0,M|59,41,0,M|59,40,0,M|59,39,0,M|59,38,0,M|59,37,0,M|59,36,0,M|59,35,0,M|59,34,0,O|59,33,0,M|59,32,0,M|59,31,0,N|59,30,0,M|59,29,0,M|59,28,0,M|59,27,0,M|59,26,0,M|59,25,0,M|59,24,0,M|59,23,0,M|59,22,0,M|59,21,0,N|59,20,0,M|59,19,0,M|59,18,2,O|59,17,0,M|59,16,0,M|59,15,0,M|59,14,0,M|59,13,0,M|59,12,0,M|59,11,0,M|59,10,0,M|59,9,0,M|59,8,0,M|59,7,0,M|59,6,0,M|59,6,0,X|59,5,0,M|59,4,0,M|59,3,0,M|59,2,0,M|59,1,0,N|59,0,0,Q|58,51,0,N|57,51,0,N|56,51,0,N|55,51,0,N|54,51,0,N|53,51,0,N|52,51,0,N|51,51,0,N|50,51,0,Q|51,50,0,Q|52,49,0,N|52,48,0,N|52,47,0,N|52,46,0,N|52,45,0,N|51,44,0,N|51,43,0,N|50,43,0,M|49,43,0,M|48,43,0,M|47,43,0,M|46,43,0,M|46,43,0,N|45,34,0,N|45,33,0,M|45,32,0,M|45,31,0,M|45,31,0,N|45,21,0,M|45,21,0,N|45,20,0,M|45,19,0,M|45,18,0,N|45,17,0,M|45,17,0,Y|45,16,0,M|45,15,0,M|45,15,2,S|45,14,0,M|45,13,0,M|45,12,0,M|45,12,0,S|45,11,0,M|45,10,0,M|45,9,0,M|45,8,0,N|45,7,0,Q|41,34,0,N|41,33,0,M|42,33,0,M|42,32,0,M|43,32,0,M|43,31,0,M|43,31,0,N|37,34,0,N|37,33,0,M|38,33,0,M|39,33,0,M|38,34,0,N|39,34,0,P|46,42,0,M|47,42,0,M|47,41,0,M|47,41,0,N|48,41,0,M|49,41,0,M|49,41,0,N|50,41,0,M|50,41,0,N|51,41,0,N|51,40,0,N|51,39,0,N|50,39,0,M|49,39,0,M|48,39,0,M|47,39,0,M|47,38,0,M|47,37,0,M|48,37,0,M|49,37,0,M|50,37,0,M|51,37,0,N|51,36,0,N|51,35,0,N|50,35,0,M|49,35,0,M|48,35,0,M|47,35,0,M|47,34,0,O|47,33,0,M|48,33,0,M|49,33,0,M|49,32,0,M|49,31,0,M|49,31,0,N|49,21,0,M|49,21,0,N|49,20,0,M|49,19,0,M|49,18,0,N|49,17,0,M|49,17,2,S|49,16,0,M|49,15,0,M|49,14,0,M|49,14,0,S|49,13,0,M|49,12,0,M|49,11,0,M|49,11,0,N|49,10,0,M|49,9,0,M|49,8,0,N|49,7,0,Q|48,32,0,M|47,32,0,M|47,31,0,M|47,31,0,N|47,21,0,M|47,21,0,N|47,20,0,M|47,19,0,M|47,18,2,O|47,17,0,M|47,16,0,M|47,15,0,M|47,14,0,M|47,13,0,M|47,12,0,M|47,11,0,M|47,11,0,N|47,10,0,M|47,10,0,N|47,9,0,M|47,9,1,P|47,8,0,N|47,7,0,Q|48,34,0,P|49,34,0,N|50,34,0,N|51,34,0,N|51,33,3,O|51,32,1,P|51,31,0,N|51,21,0,N|51,20,1,P|51,19,3,O|51,18,0,N|51,17,0,N|51,16,0,N|51,15,0,N|51,14,0,N|51,13,0,N|51,12,0,N|51,11,0,N|51,10,0,N|51,9,0,N|51,8,0,N|51,7,0,Q|51,6,0,Q|51,5,0,Q|51,4,0,Q|51,3,0,Q|50,3,0,Z|50,2,0,Q|50,0,0,Q|51,0,0,Q|51,1,0,Q|50,1,0,Q|51,2,0,Q|50,36,0,M|49,36,0,M|48,36,0,M|47,36,0,M|48,38,0,M|49,38,0,M|50,38,0,M|51,38,0,N|50,40,0,M|49,40,0,M|48,40,0,M|47,40,0,M|48,42,0,M|49,42,0,M|50,42,0,M|51,42,0,N|50,44,0,N|49,44,0,N|48,44,0,N|47,44,0,N|46,44,0,N|45,44,0,N|43,44,0,N|42,44,0,N|41,44,0,N|40,44,0,N|39,44,0,N|38,44,0,N|37,44,0,N|36,44,0,N|36,43,0,N|36,42,0,N|36,41,0,N|36,40,0,N|36,39,0,N|36,38,0,N|36,37,0,N|36,36,0,N|36,35,0,N|35,34,0,N|35,33,0,M|34,33,0,M|33,33,0,M|32,33,0,M|31,33,0,M|31,33,0,N|30,33,0,M|29,33,0,M|29,33,1,S|28,33,0,M|27,33,0,M|26,33,0,M|25,33,0,M|24,33,0,M|23,33,0,M|22,33,0,M|21,33,0,M|20,33,0,M|19,33,0,N|18,33,0,M|18,33,0,T|17,33,0,M|17,33,0,T|16,33,0,M|15,33,0,M|14,33,0,M|13,33,0,M|12,33,0,M|11,33,0,N|10,33,0,M|9,33,0,M|9,34,0,M|9,35,0,N|10,35,0,N|11,35,0,N|12,35,0,M|13,35,0,M|14,35,0,M|15,35,0,M|16,35,0,M|17,35,0,M|17,35,0,U|18,35,0,M|18,35,0,U|19,35,0,N|20,35,0,M|21,35,0,M|22,35,0,M|23,35,0,M|24,35,0,M|25,35,0,M|26,35,0,M|27,35,0,M|28,35,0,N|9,32,0,M|8,32,0,N|8,31,0,N|8,30,0,N|8,29,1,P|8,28,0,N|8,27,0,N|9,27,0,M|10,27,0,M|11,27,0,N|12,27,0,M|13,27,0,M|14,27,0,M|15,27,0,M|16,27,0,M|17,27,0,M|17,27,0,U|18,27,0,M|18,27,0,U|18,28,0,M|19,28,3,O|19,29,1,P|20,29,0,M|21,29,0,M|22,29,0,M|23,29,0,M|23,28,2,O|24,28,0,P|25,28,0,N|26,28,0,N|27,28,0,N|28,28,0,N|29,28,0,N|29,29,0,M|29,29,1,P|30,29,0,M|30,30,0,M|31,30,0,M|32,30,0,M|32,31,0,M|32,31,0,N|33,31,0,M|33,31,0,P|9,31,0,M|10,31,0,M|11,31,0,N|11,30,1,P|11,29,3,O|12,29,0,M|13,29,0,M|14,29,0,M|15,29,0,M|16,29,0,M|17,29,0,M|17,30,0,M|18,30,0,M|18,31,0,M|19,31,0,N|20,31,0,M|21,31,0,M|22,31,0,M|23,31,0,M|24,31,0,M|24,30,0,M|25,30,0,M|26,30,0,M|27,30,0,M|28,30,0,M|28,31,0,M|29,31,0,M|29,31,0,N|10,30,0,M|10,34,0,M|10,32,0,M|11,34,0,N|11,32,0,N|12,34,0,M|12,32,0,M|13,34,0,M|13,32,0,M|13,31,0,M|14,31,0,M|15,31,0,M|16,31,0,M|14,34,0,M|14,32,0,M|15,34,0,M|15,32,0,M|16,34,0,M|16,32,0,M|17,34,0,M|17,32,0,M|18,34,0,M|18,32,0,M|19,34,0,N|19,32,0,N|20,34,0,M|20,32,0,M|21,34,0,M|21,32,0,M|21,32,2,[|22,34,0,M|22,32,0,M|23,34,0,M|23,32,0,M|24,34,0,M|24,32,0,M|24,32,0,\|25,34,0,M|25,32,0,M|26,34,0,M|26,32,0,M|27,34,0,M|27,32,0,M|28,34,0,M|28,32,0,M|29,34,0,M|29,32,0,M|30,34,0,M|30,32,0,M|31,32,0,M|31,32,0,N|32,32,0,M|33,32,0,M|34,32,0,M|34,34,2,O|32,34,0,N|31,34,0,N|30,35,0,N|29,35,0,N|28,36,0,N|27,36,0,N|26,37,0,N|25,37,0,N|24,37,0,N|23,37,0,M|22,37,0,M|21,37,0,M|20,37,0,M|19,37,0,N|18,37,0,N|17,37,0,P|16,37,0,N|15,37,0,N|14,37,0,N|13,37,0,N|12,37,0,N|11,37,0,O|10,37,0,M|9,37,0,M|8,37,0,N|7,37,0,N|6,37,0,N|5,37,0,N|5,38,0,M|5,39,0,M|5,40,0,M|4,40,0,M|4,41,0,M|3,41,0,N|2,41,0,Q|5,41,0,M|6,41,0,M|7,41,0,M|8,41,0,M|9,41,0,M|10,41,0,M|11,41,0,M|12,41,0,M|13,41,0,M|14,41,0,M|15,41,0,M|16,41,0,M|16,40,0,M|17,40,0,M|18,40,0,M|18,39,0,M|19,39,0,N|20,39,0,N|17,39,0,M|16,39,0,M|15,39,0,M|14,39,0,M|13,39,0,M|12,39,0,M|11,39,0,M|10,39,0,M|9,39,0,M|8,39,0,M|7,39,0,M|15,40,0,M|14,40,0,M|13,40,0,M|12,40,0,M|11,40,0,M|10,40,0,M|9,40,0,M|8,40,0,M|7,40,0,M|6,40,0,M|6,39,0,M|6,38,0,M|7,38,0,M|8,38,0,M|8,36,0,N|9,38,0,M|10,38,0,M|11,38,0,M|12,38,0,M|13,38,0,M|14,38,0,M|15,38,0,M|16,38,0,M|17,38,0,M|18,38,0,M|19,38,0,N|20,38,0,M|21,38,0,M|22,38,0,N|24,38,0,N|23,38,0,N|22,39,0,N|21,39,0,N|20,40,0,Q|19,40,0,N|18,41,0,N|17,41,0,N|16,42,0,N|15,42,0,N|14,42,0,N|13,42,0,N|12,42,0,N|11,42,0,N|10,42,0,N|9,42,0,N|8,42,0,N|7,42,0,N|6,42,0,N|5,42,0,N|4,42,0,N|3,42,0,N|2,42,0,N|1,42,0,Q|1,41,0,Q|1,40,0,Q|2,40,0,Q|3,40,0,N|4,39,0,N|4,38,0,N|4,37,0,N|8,26,0,N|8,24,0,N|9,26,0,M|9,26,0,P|9,24,0,M|10,26,0,M|10,26,0,N|10,24,0,M|11,26,0,N|11,24,0,N|12,26,0,M|12,24,0,M|13,26,0,M|13,24,0,M|14,26,0,M|14,24,0,M|15,26,0,M|15,24,0,M|16,26,0,M|16,24,0,M|17,26,0,M|17,24,0,M|18,26,0,M|18,24,0,M|18,23,0,M|20,22,0,M|18,22,0,M|20,21,0,M|18,21,0,M|20,20,0,M|18,20,0,M|20,19,0,M|18,19,0,M|18,19,0,U|20,18,0,M|18,18,0,M|20,17,0,M|18,17,0,M|18,17,0,T|20,16,0,M|18,16,0,M|20,15,0,M|18,15,0,N|20,14,0,M|18,14,0,M|20,13,0,N|18,13,0,M|20,12,0,Q|18,12,0,M|18,11,0,N|19,26,0,N|20,28,0,N|19,27,0,N|21,28,0,N|23,27,0,M|22,28,0,N|24,27,0,M|25,27,0,M|26,27,0,M|26,27,0,N|27,27,0,M|28,27,0,M|29,27,0,M|30,28,2,O|31,29,0,M|32,29,0,M|33,30,0,M|34,31,0,M|34,31,0,N|35,32,0,M|36,32,0,N|37,32,0,M|38,32,0,M|39,32,0,M|40,32,0,M|42,31,0,M|42,31,0,N|41,32,0,M|44,21,0,M|44,21,0,N|44,20,0,M|44,19,0,M|44,18,0,N|44,17,0,M|44,17,1,S|44,16,0,M|44,15,0,M|44,15,2,S|44,14,0,M|44,13,0,M|44,12,0,M|44,11,0,M|44,10,0,M|44,10,0,S|44,9,0,M|44,8,0,N|44,7,0,Q|26,22,0,M|26,21,0,M|26,20,0,M|24,20,0,M|26,19,0,M|24,19,0,M|26,18,0,M|26,18,0,\|24,18,0,M|26,17,0,M|24,17,0,M|26,16,0,N|24,16,0,M|26,15,0,N|24,15,0,N|24,14,0,N|22,18,0,M|22,17,0,M|22,16,0,M|22,15,0,M|22,14,0,N|22,13,0,N|11,11,0,M|11,10,0,N|11,9,0,Q|9,9,0,Q|5,9,0,Q|66,52,0,Q|66,51,0,Q|66,50,0,Q|64,50,0,M|66,49,0,Q|64,49,0,M|66,48,0,Q|64,48,0,M|66,47,0,Q|64,47,0,M|66,46,0,Q|64,46,0,M|66,45,0,Q|64,45,0,M|66,44,0,Q|64,44,0,M|66,43,0,Q|64,43,0,M|66,42,0,Q|64,42,0,M|66,41,0,Q|64,41,0,M|66,40,0,Q|64,40,0,M|66,39,0,Q|64,39,0,M|66,38,0,Q|64,38,0,M|66,37,0,Q|64,37,0,M|66,36,0,Q|64,36,0,M|66,35,0,Q|67,35,0,Q|68,35,0,Q|69,35,0,Q|70,35,0,Q|71,35,0,Q|72,35,0,Q|73,35,0,Q|74,35,0,Q|75,35,0,Q|76,35,0,Q|77,35,0,Q|78,35,0,Q|79,35,0,Q|80,35,0,Q|81,35,0,Q|82,35,0,Q|83,35,0,Q|84,35,0,Q|84,36,0,Q|84,37,0,Q|84,38,0,Q|85,41,0,Q|86,41,0,Q|87,41,0,Q|88,41,0,Q|89,41,0,Q|90,41,0,Q|91,41,0,Q|92,41,0,Q|93,41,0,Q|94,41,0,Q|95,41,0,Q|96,41,0,Q|97,41,0,Q|97,39,0,N|96,39,0,M|95,39,0,M|94,39,0,M|94,39,0,]|93,39,0,M|92,39,0,M|91,39,0,M|90,39,0,M|89,39,0,M|88,39,0,M|87,39,0,M|86,39,0,M|86,39,0,]|86,38,0,M|86,37,0,M|87,37,0,M|88,37,0,M|89,37,0,M|90,37,0,M|91,37,0,M|92,37,0,M|93,37,0,M|94,37,0,M|95,37,0,M|96,37,0,M|97,37,0,N|98,37,0,Q|98,36,0,Q|98,35,0,Q|97,35,0,N|96,35,0,M|95,35,0,M|94,35,0,M|93,35,0,M|92,35,0,M|91,35,0,M|90,35,0,M|89,35,0,M|88,35,0,M|87,35,0,M|86,35,0,M|86,34,0,M|85,34,0,N|85,33,1,O|84,33,3,O|83,33,0,M|82,33,0,M|81,33,0,M|80,33,0,M|79,33,0,M|78,33,0,M|77,33,0,M|76,33,0,M|75,33,0,M|74,33,0,M|73,33,0,M|72,33,0,M|71,33,0,M|70,33,0,M|69,33,0,M|68,33,0,M|67,33,0,M|67,32,0,M|67,31,0,N|68,31,0,N|69,31,0,N|70,31,0,N|71,31,0,N|72,31,0,N|73,31,0,N|74,31,0,N|75,31,0,P|76,31,0,N|77,31,0,N|78,31,0,N|79,31,0,N|80,31,0,N|81,31,0,N|82,31,0,N|83,31,0,N|84,31,0,N|85,31,0,N|86,31,0,M|86,31,0,]|86,32,0,M|87,32,0,M|87,33,0,M|88,33,0,M|89,33,0,M|90,33,0,M|91,33,0,M|92,33,0,M|93,33,0,M|94,33,0,M|95,33,0,M|96,33,0,M|96,33,0,N|97,33,0,M|98,33,0,M|99,33,0,M|99,34,0,N|100,34,0,N|100,35,2,V|101,35,0,Q|102,35,0,Q|102,34,0,Q|102,33,0,Q|101,33,0,N|101,32,0,N|100,32,0,M|100,31,0,M|99,31,0,M|98,31,0,M|97,31,0,M|96,31,0,M|96,31,1,P|95,31,0,M|94,31,0,M|94,31,0,]|93,31,0,M|92,31,0,M|91,31,0,M|90,31,0,M|89,31,0,M|88,31,0,M|88,30,0,N|87,30,0,N|87,29,0,M|86,29,0,M|85,29,0,N|84,29,0,N|83,29,0,M|82,29,0,M|81,29,0,M|80,29,0,M|79,29,0,M|78,29,0,M|77,29,0,M|77,29,0,N|76,29,0,M|75,29,0,M|74,29,0,M|73,29,0,M|73,29,0,N|72,29,0,M|71,29,0,M|70,29,0,M|69,29,0,M|68,29,0,M|67,29,0,M|67,28,0,M|67,27,0,M|68,27,0,M|69,27,0,M|70,27,0,M|71,27,0,M|72,27,0,M|73,27,0,M|73,27,0,N|74,27,0,M|75,27,0,M|76,27,0,M|77,27,0,M|77,27,0,N|78,27,0,M|79,27,0,M|80,27,0,M|81,27,0,M|82,27,0,M|83,27,0,M|84,27,0,N|85,27,0,N|86,27,0,M|87,27,0,M|88,27,0,M|88,28,0,M|89,28,0,M|89,29,0,M|90,29,0,M|91,29,0,M|92,29,0,M|93,29,0,M|94,29,0,M|95,29,0,M|96,29,0,M|97,29,0,M|98,29,0,M|99,29,0,M|100,29,0,M|101,29,0,M|101,30,0,N|102,30,0,N|102,31,0,Q|103,31,0,Q|104,31,0,Q|105,31,0,Q|106,31,0,Q|107,31,0,Q|107,29,0,Q|106,29,0,N|105,29,0,M|104,29,0,M|103,29,0,M|103,28,0,M|102,28,0,M|102,27,0,M|101,27,0,M|100,27,0,M|99,27,0,M|98,27,0,M|97,27,0,M|96,27,0,M|95,27,0,M|94,27,0,M|93,27,0,M|92,27,0,M|91,27,0,M|90,27,0,M|90,26,0,M|89,26,0,M|89,25,0,M|88,25,0,M|87,25,0,M|86,25,0,M|85,25,0,N|84,25,0,N|83,25,0,M|82,25,0,M|81,25,0,M|80,25,0,M|79,25,0,M|78,25,0,M|77,25,0,M|77,25,0,N|76,25,0,M|75,25,0,M|74,25,0,M|73,25,0,M|73,25,0,N|72,25,0,M|71,25,0,M|70,25,0,M|69,25,0,M|68,25,0,M|67,25,0,M|67,24,0,M|67,23,0,M|68,23,0,M|69,23,0,M|70,23,0,M|71,23,0,M|72,23,0,M|73,23,0,M|73,23,0,N|75,23,0,M|76,23,0,M|77,23,0,M|77,23,0,N|78,23,0,M|79,23,0,M|80,23,0,M|81,23,0,M|82,23,0,M|83,23,0,M|84,23,0,N|85,23,0,N|86,23,0,M|87,23,0,M|88,23,0,M|89,23,0,M|90,23,0,M|91,23,0,M|91,22,0,N|91,21,0,M|91,20,0,M|91,19,0,M|91,18,0,M|91,17,0,M|91,16,0,M|91,15,0,M|91,14,0,M|91,13,0,M|91,12,0,N|91,11,0,Q|90,22,0,N|89,22,0,P|89,21,0,M|88,21,0,M|87,21,0,M|87,20,0,M|87,19,0,M|87,18,0,M|87,17,0,M|87,16,0,M|87,15,0,M|87,14,0,M|87,13,0,M|87,12,0,N|87,11,0,Q|88,20,0,M|89,20,0,M|89,19,0,M|89,18,0,M|89,17,0,M|89,16,0,M|89,15,0,M|89,14,0,M|89,13,0,M|89,12,0,N|89,11,0,Q|88,22,0,N|87,22,0,N|86,22,0,N|85,22,0,N|85,21,0,N|84,21,0,N|83,21,0,N|82,21,0,N|81,21,0,N|80,21,0,N|79,21,0,N|79,20,0,M|79,19,0,M|79,18,0,N|79,17,0,Q|80,20,0,M|81,20,0,M|81,19,0,M|82,19,0,M|83,19,0,M|83,18,0,N|83,17,0,Q|82,18,0,N|81,18,0,N|81,17,0,Q|82,20,0,M|83,20,0,M|84,20,0,M|85,20,1,P|85,19,1,O|85,18,0,N|85,17,0,N|85,16,0,N|84,16,0,Q|84,15,0,Q|84,14,0,Q|85,14,0,N|85,13,0,N|85,12,0,N|85,11,0,Q|85,15,0,N|84,22,0,N|83,22,0,M|82,22,0,M|81,22,0,M|80,22,0,M|79,22,0,M|78,22,0,M|77,22,0,M|77,22,0,N|77,21,0,N|76,21,0,N|75,21,0,P|74,21,0,N|73,21,0,N|72,21,0,N|71,21,0,N|70,21,0,N|69,21,0,N|68,21,0,N|67,21,0,N|67,20,0,M|67,19,0,M|68,19,0,M|69,19,0,M|70,19,0,M|71,19,0,M|71,18,0,N|71,17,0,Q|70,18,0,N|69,18,0,N|69,17,0,Q|68,17,0,Q|67,17,0,Q|68,18,0,N|67,18,0,N|68,20,0,M|69,20,0,M|70,20,0,M|71,20,0,M|72,20,0,M|73,20,0,M|73,19,0,M|74,19,0,M|75,19,0,M|76,19,0,M|77,19,0,M|77,18,0,N|77,17,0,Q|76,17,0,Q|75,17,0,Q|74,17,0,Q|73,17,0,Q|76,18,0,N|75,18,0,N|74,18,0,N|73,18,0,N|74,20,0,M|75,20,0,M|76,20,0,M|77,20,0,M|76,22,0,M|75,22,0,M|74,22,0,M|73,22,0,M|73,22,0,N|72,22,0,M|71,22,0,M|70,22,0,M|69,22,0,M|68,22,0,M|67,22,0,M|68,24,0,M|69,24,0,M|70,24,0,M|71,24,0,M|72,24,0,M|73,24,0,M|73,24,1,P|74,24,0,M|75,24,0,M|76,24,0,M|77,24,0,M|77,24,1,P|78,24,0,M|79,24,0,M|80,24,0,M|81,24,0,M|82,24,0,M|83,24,0,M|84,24,0,N|85,24,0,N|86,24,0,M|87,24,0,M|88,24,0,M|89,24,0,M|90,25,0,M|91,25,0,M|92,25,0,M|93,25,0,M|94,25,0,M|95,25,0,M|96,25,0,M|97,25,0,M|98,25,0,M|99,25,0,M|100,25,0,M|101,25,0,M|102,25,0,M|103,25,0,M|103,26,0,M|104,26,0,M|104,27,0,M|105,27,0,M|105,25,0,M|105,24,0,M|104,24,0,M|104,23,0,M|103,23,0,M|102,23,0,M|101,23,0,M|100,23,0,M|99,23,0,M|98,23,0,M|97,23,0,M|96,23,0,M|95,23,0,M|94,23,0,M|93,23,0,M|93,22,0,N|93,21,0,M|94,21,0,M|94,21,0,]|95,21,0,M|96,21,0,M|96,21,1,P|97,21,0,M|98,21,0,M|99,21,0,M|100,21,0,M|101,21,0,N|102,21,0,Q|103,21,0,Q|104,21,0,Q|105,21,0,Q|106,21,0,Q|102,20,0,Q|102,19,0,Q|101,19,0,N|100,19,0,M|99,19,0,M|99,18,0,N|99,17,0,Q|100,18,0,N|101,18,0,N|101,17,0,Q|102,17,0,Q|102,18,0,Q|101,20,0,N|100,20,0,M|99,20,0,M|98,20,0,M|97,20,0,M|97,19,0,M|96,19,0,M|96,19,0,N|95,19,0,M|94,19,0,M|93,19,0,M|93,18,0,M|93,17,0,M|94,17,0,M|95,17,0,M|96,17,0,M|97,17,0,N|97,16,0,N|98,16,0,Q|98,15,0,Q|98,14,0,Q|97,15,0,N|96,15,0,M|95,15,0,M|95,14,0,M|95,13,0,M|95,12,0,N|95,11,0,Q|96,14,0,M|96,16,0,M|95,16,0,M|94,16,0,M|93,16,0,M|93,15,0,M|93,14,0,M|93,13,0,M|93,12,0,N|93,11,0,Q|94,18,0,M|95,18,0,M|96,18,0,M|96,18,0,N|97,18,0,N|96,20,0,M|96,20,0,N|95,20,0,M|94,20,0,M|93,20,0,M|94,22,0,N|95,22,0,N|96,22,0,N|97,22,0,N|98,22,0,N|99,22,0,N|100,22,0,N|101,22,0,N|102,22,0,N|103,22,0,N|104,22,0,N|105,23,0,M|106,23,0,N|107,23,0,Q|107,22,0,Q|105,26,0,M|104,25,0,M|103,24,0,M|102,24,0,M|101,24,0,M|100,24,0,M|99,24,0,M|98,24,0,M|97,24,0,M|96,24,0,M|95,24,0,M|94,24,0,M|93,24,0,M|92,24,0,M|91,26,0,M|92,26,0,M|93,26,0,M|94,26,0,M|95,26,0,M|96,26,0,M|97,26,0,M|98,26,0,M|99,26,0,M|100,26,0,M|101,26,0,M|102,26,0,M|103,27,0,M|104,28,0,M|105,28,0,M|107,30,0,Q|106,30,0,N|105,30,0,N|104,30,0,N|103,30,0,N|102,29,0,M|101,28,0,M|100,28,0,M|99,28,0,M|98,28,0,M|97,28,0,M|96,28,0,M|95,28,0,M|94,28,0,M|93,28,0,M|92,28,0,M|91,28,0,M|90,28,0,M|89,27,0,M|88,26,0,M|87,26,0,M|86,26,0,M|85,26,1,O|84,26,0,N|83,26,0,M|82,26,0,M|81,26,0,M|80,26,0,M|79,26,0,M|78,26,0,M|77,26,0,M|77,26,0,N|76,26,0,M|75,26,0,M|74,26,0,M|73,26,0,M|73,26,1,O|72,26,0,M|71,26,0,M|70,26,0,M|69,26,0,M|68,26,0,M|67,26,0,M|68,28,0,M|69,28,0,M|70,28,0,M|71,28,0,M|72,28,0,M|73,28,0,M|73,28,1,P|74,28,0,M|75,28,0,M|76,28,0,M|77,28,0,M|77,28,1,P|78,28,0,M|79,28,0,M|80,28,0,M|81,28,0,M|82,28,0,M|83,28,0,M|84,28,0,N|85,28,0,N|86,28,0,M|87,28,0,M|88,29,0,M|89,30,0,P|90,30,0,N|91,30,0,N|92,30,0,N|93,30,0,N|94,30,0,N|95,30,0,N|96,30,0,N|97,30,0,N|98,30,0,N|99,30,0,N|100,30,0,N|101,31,0,N|102,32,0,Q|101,34,0,N|100,33,0,M|99,32,0,M|98,32,0,M|97,32,0,M|96,32,0,M|96,32,0,N|95,32,0,M|94,32,0,M|93,32,0,M|92,32,0,M|91,32,0,M|90,32,0,M|89,32,0,M|88,32,0,M|87,31,0,M|86,30,0,N|85,30,0,N|84,30,0,N|83,30,0,M|82,30,0,M|81,30,0,M|80,30,0,M|79,30,0,M|78,30,0,M|77,30,0,M|77,30,0,N|76,30,0,M|75,30,0,M|74,30,0,M|73,30,0,M|73,30,0,N|72,30,0,M|71,30,0,M|70,30,0,M|69,30,0,M|68,30,0,M|67,30,0,M|68,32,0,M|69,32,0,M|70,32,0,M|71,32,0,M|72,32,0,M|73,32,0,M|74,32,0,M|75,32,0,M|76,32,0,M|77,32,0,M|78,32,0,M|79,32,0,M|80,32,0,M|81,32,0,M|82,32,0,M|83,32,0,M|84,32,0,M|85,32,1,P|86,33,0,M|87,34,0,M|88,34,0,M|89,34,0,M|90,34,0,M|91,34,0,M|92,34,0,M|93,34,0,M|94,34,0,M|95,34,0,M|96,34,0,M|96,34,0,N|97,34,0,N|99,35,0,Q|98,34,0,N|97,36,0,N|96,36,0,M|95,36,0,M|94,36,0,M|93,36,0,M|92,36,0,M|91,36,0,M|90,36,0,M|89,36,0,M|88,36,0,M|87,36,0,M|86,36,0,M|87,38,0,M|88,38,0,M|89,38,0,M|90,38,0,M|91,38,0,M|92,38,0,M|93,38,0,M|94,38,0,M|95,38,0,M|96,38,0,M|97,38,0,N|98,38,0,Q|97,40,0,N|96,40,0,N|95,40,0,N|94,40,0,N|93,40,0,N|92,40,0,N|91,40,0,N|90,40,0,N|89,40,0,N|88,40,0,N|87,40,0,N|86,40,0,N|85,40,0,N|85,39,0,N|85,38,0,N|85,37,0,N|85,36,0,N|85,35,0,N|84,34,0,N|83,34,0,N|82,34,0,N|81,34,0,N|80,34,0,N|79,34,0,N|78,34,0,N|77,34,0,N|76,34,0,N|75,34,0,N|74,34,0,N|73,34,0,N|72,34,0,N|71,34,0,N|70,34,0,N|69,34,0,N|68,34,0,N|67,34,0,N|64,35,0,M|66,34,0,N|64,34,0,N|66,33,0,N|64,33,0,M|66,32,0,M|64,32,0,M|66,31,0,N|64,31,0,N|66,30,0,N|64,30,0,M|66,29,0,N|64,29,0,M|66,28,0,N|64,28,0,M|66,27,0,N|64,27,0,M|66,26,0,N|64,26,0,M|66,25,0,N|64,25,0,M|66,24,0,N|64,24,0,M|66,23,0,N|64,23,0,M|66,22,0,N|64,22,0,M|66,21,0,N|64,21,0,N|66,20,0,M|64,20,0,M|66,19,0,N|64,19,0,M|66,18,0,N|64,18,0,N|66,17,0,Q|64,17,0,M|66,16,0,Q|64,16,0,M|66,15,0,Q|64,15,0,M|66,14,0,Q|64,14,0,M|66,13,0,Q|64,13,0,M|66,12,0,Q|64,12,0,M|66,11,0,Q|64,11,0,M|66,10,0,Q|64,10,0,M|66,9,0,Q|64,9,0,M|66,8,0,Q|64,8,0,M|66,7,0,Q|64,7,0,M|66,6,0,Q|64,6,0,M|66,5,0,Q|64,5,0,M|66,4,0,Q|64,4,0,M|66,3,0,Q|64,3,0,M|66,2,0,Q|64,2,0,M|66,1,0,Q|64,1,0,N|66,0,0,Q|64,0,0,Q|60,50,0,M|60,49,0,M|62,48,0,M|60,48,0,M|62,47,0,M|60,47,0,M|62,46,0,M|60,46,0,M|62,45,0,M|60,45,0,M|60,45,0,T|62,44,0,M|60,44,0,M|62,43,0,M|60,43,0,M|62,42,0,M|60,42,0,M|62,41,0,M|60,41,0,M|62,40,0,M|60,40,0,M|62,39,0,M|60,39,0,M|62,38,0,M|60,38,0,M|62,37,0,M|60,37,0,M|62,36,0,M|60,36,0,M|60,36,0,T|62,35,0,M|60,35,0,M|62,34,0,N|62,33,0,M|60,33,0,M|62,32,0,M|60,32,0,M|62,31,0,N|60,31,0,P|62,30,0,M|60,30,0,M|62,29,0,M|60,29,0,M|62,28,0,M|60,28,0,M|62,27,0,M|60,27,0,M|62,26,0,M|60,26,0,M|62,25,0,M|60,25,0,M|62,24,0,M|60,24,0,M|62,23,0,M|60,23,0,M|62,22,0,M|60,22,0,M|62,21,0,N|60,21,0,P|62,20,0,M|60,20,0,M|62,19,0,M|60,19,0,M|62,18,0,N|62,17,0,M|60,17,0,M|62,16,0,M|60,16,0,M|60,16,0,T|62,15,0,M|60,15,0,M|62,14,0,M|60,14,0,M|62,13,0,M|60,13,0,M|62,12,0,M|60,12,0,M|62,11,0,M|60,11,0,M|62,10,0,M|60,10,0,M|62,9,0,M|60,9,0,M|62,8,0,M|60,8,0,M|62,7,0,M|60,7,0,M|60,7,0,T|62,6,0,M|60,6,0,M|62,5,0,M|60,5,0,M|62,4,0,M|60,4,0,M|62,3,0,M|60,3,0,M|62,2,0,M|60,2,0,M|62,1,0,N|60,1,0,N|62,0,0,Q|60,0,0,Q|52,50,0,N|54,48,0,M|54,47,0,M|54,46,0,M|54,45,0,M|54,44,0,M|52,44,0,N|54,43,0,M|52,43,0,N|54,42,0,M|52,42,0,N|54,41,0,M|52,41,0,N|54,40,0,M|52,40,0,N|54,39,0,M|52,39,0,N|54,38,0,M|52,38,0,N|54,37,0,M|52,37,0,N|54,36,0,M|52,36,0,N|54,35,0,M|52,35,0,N|54,34,0,N|52,34,0,N|54,33,0,M|52,33,1,O|54,32,0,M|52,32,0,M|52,31,0,N|52,21,0,N|54,20,0,M|52,20,0,M|54,19,0,M|52,19,1,O|54,18,0,N|52,18,0,N|54,17,0,M|52,17,0,N|54,16,0,M|52,16,0,N|54,15,0,M|52,15,0,N|54,14,0,M|52,14,0,N|54,13,0,M|52,13,0,N|54,12,0,M|52,12,0,N|54,11,0,M|52,11,0,N|54,10,0,M|52,10,0,N|54,9,0,M|52,9,0,N|54,8,0,M|52,8,0,N|54,7,0,M|52,7,0,N|54,6,0,M|52,6,0,N|54,5,0,M|52,5,0,N|54,4,0,M|52,4,0,N|54,3,0,M|52,3,0,N|54,2,0,M|52,2,0,N|54,1,0,N|52,1,0,N|54,0,0,Q|52,0,0,Q|58,48,0,M|58,47,0,M|58,46,0,M|58,46,0,^|56,46,0,M|58,45,0,M|56,45,0,M|58,44,0,M|56,44,0,M|58,43,0,M|56,43,0,M|58,42,0,M|56,42,0,M|58,41,0,M|56,41,0,M|58,40,0,M|56,40,0,M|58,39,0,M|56,39,0,M|58,38,0,M|56,38,0,M|58,37,0,M|56,37,0,M|58,36,0,M|56,36,0,M|58,35,0,M|56,35,0,M|58,34,0,N|56,34,0,N|58,33,0,M|56,33,0,M|58,32,0,M|56,32,0,M|58,31,0,N|58,30,0,M|58,30,0,N|58,29,0,M|58,29,0,N|58,28,0,M|58,28,0,N|58,27,0,M|58,27,0,N|58,26,0,M|58,26,0,N|58,25,0,M|58,25,0,N|58,24,0,M|58,24,0,N|58,23,0,M|58,23,0,N|58,22,0,M|58,22,0,N|58,21,0,N|58,20,0,M|56,20,0,M|58,19,0,M|56,19,0,M|58,18,0,N|56,18,0,N|58,17,0,M|56,17,0,M|58,16,0,M|56,16,0,M|58,15,0,M|56,15,0,M|58,14,0,M|56,14,0,M|58,13,0,M|56,13,0,M|58,12,0,M|56,12,0,M|58,11,0,M|56,11,0,M|58,10,0,M|56,10,0,M|58,9,0,M|56,9,0,M|58,8,0,M|56,8,0,M|58,7,0,M|56,7,0,M|58,6,0,M|58,6,0,^|56,6,0,M|58,5,0,M|56,5,0,M|58,4,0,M|56,4,0,M|58,3,0,M|56,3,0,M|58,2,0,M|56,2,0,M|58,1,0,N|56,1,0,N|58,0,0,Q|56,0,0,Q|46,41,0,M|46,41,0,N|46,40,0,M|46,40,0,N|46,39,0,M|46,39,0,N|46,38,0,M|46,38,0,N|46,37,0,M|46,37,0,N|46,36,0,M|46,36,0,N|46,35,0,M|46,35,0,N|46,34,0,N|46,33,0,M|44,33,0,M|46,32,0,M|44,32,0,M|46,31,0,M|46,31,0,P|44,31,0,M|44,31,0,N|46,21,0,M|46,21,0,P|46,20,0,M|46,19,0,M|46,18,0,N|46,17,0,M|46,17,3,S|46,16,0,M|46,15,0,M|46,14,0,M|46,14,3,S|46,13,0,M|46,13,3,S|46,12,0,M|46,11,0,M|46,10,0,M|46,9,0,M|46,8,0,N|46,7,0,Q|40,34,0,O|40,33,0,M|43,33,0,M|36,34,0,N|36,33,0,N|50,33,0,M|50,32,0,M|50,31,0,M|50,31,0,N|48,31,0,M|50,21,0,M|50,21,0,N|48,21,0,M|50,20,0,M|48,20,0,M|50,19,0,M|48,19,0,M|50,18,0,N|48,18,0,N|50,17,0,M|48,17,0,M|48,17,2,S|50,16,0,M|50,16,3,S|48,16,0,M|50,15,0,M|50,15,3,S|48,15,0,M|50,14,0,M|48,14,0,M|50,13,0,M|48,13,0,M|50,12,0,M|48,12,0,M|50,11,0,M|50,11,0,N|48,11,0,M|48,11,0,N|50,10,0,M|48,10,0,M|50,9,0,M|48,9,0,M|50,8,0,N|48,8,0,N|50,7,0,Q|48,7,0,Q|8,33,0,N|8,34,1,P|9,36,0,M|8,35,0,N|10,36,0,M|11,36,0,N|12,36,0,M|13,36,0,M|14,36,0,M|15,36,0,M|16,36,0,M|17,36,0,M|18,36,0,M|19,36,0,N|20,36,0,M|21,36,0,M|22,36,0,M|22,36,2,[|23,36,0,M|24,36,0,M|25,36,0,M|26,36,0,N|9,30,0,M|9,29,0,M|9,28,0,M|10,28,0,M|11,28,0,N|12,28,0,M|13,28,0,M|14,28,0,M|15,28,0,M|16,28,0,M|17,28,0,M|18,29,0,M|19,30,0,N|20,30,0,M|21,30,0,M|22,30,0,M|24,29,0,M|23,30,0,M|25,29,0,M|26,29,0,M|27,29,0,M|28,29,0,M|29,30,0,M|29,30,3,O|30,31,0,M|30,31,0,N|31,31,0,M|31,31,0,N|12,31,0,M|12,30,0,M|10,29,0,M|13,30,0,M|14,30,0,M|15,30,0,M|16,30,0,M|17,31,0,M|25,31,0,M|26,31,0,M|27,31,0,M|90,24,0,M|92,23,0,M|91,24,0,M|92,22,0,N|92,21,0,M|90,21,0,M|92,20,0,M|90,20,0,M|92,19,0,M|90,19,0,M|92,18,0,M|90,18,0,M|92,17,0,M|90,17,0,M|92,16,0,M|90,16,0,M|92,15,0,M|90,15,0,M|92,14,0,M|90,14,0,M|92,13,0,M|90,13,0,M|92,12,0,N|90,12,0,N|92,11,0,Q|90,11,0,Q|86,21,0,M|86,21,0,]|86,20,0,M|88,19,0,M|86,19,0,M|88,18,0,M|86,18,0,M|88,17,0,M|86,17,0,M|88,16,0,M|86,16,0,M|88,15,0,M|86,15,0,M|88,14,0,M|86,14,0,M|88,13,0,M|86,13,0,M|86,13,0,]|88,12,0,N|86,12,0,N|88,11,0,Q|86,11,0,Q|78,21,0,N|78,20,0,M|80,19,0,M|78,19,0,M|80,18,0,N|78,18,0,N|80,17,0,Q|78,17,0,Q|84,19,3,O|84,18,0,N|84,17,0,Q|82,17,0,Q|72,19,0,M|72,18,0,N|72,17,0,Q|70,17,0,Q|105,22,0,N|107,21,0,Q|106,22,0,N|98,19,0,M|98,18,0,N|100,17,0,V|98,17,0,Q|97,14,0,N|97,13,0,N|97,12,0,N|97,11,0,Q|94,15,0,M|94,14,0,M|96,13,0,M|94,13,0,M|94,13,0,]|96,12,0,N|94,12,0,N|96,11,0,Q|94,11,0,Q|4,26,0,Q|5,26,0,Q|6,26,0,Q|7,26,0,Q|48,21,0,N|48,31,0,N|32,35,0,Q|33,35,0,Q|34,35,0,Q|32,17,0,Q|33,17,0,Q|34,17,0,Q|33,18,0,N|33,34,0,N|37,35,0,M|37,36,0,M|37,37,0,M|37,38,0,M|37,39,0,M|37,40,0,M|37,41,0,M|37,42,0,M|37,43,0,M|38,35,0,M|38,36,0,M|38,37,0,M|38,38,0,M|38,39,0,M|38,40,0,M|38,41,0,M|38,42,0,M|38,43,0,M|39,35,0,M|39,36,0,M|39,37,0,M|39,38,0,M|39,39,0,M|39,40,0,M|39,41,0,M|39,42,0,M|39,43,0,M|40,35,0,M|40,36,0,M|40,37,0,M|40,38,0,M|40,39,0,M|40,40,0,M|40,41,0,M|40,42,0,M|40,43,0,M|41,35,0,M|41,36,0,M|41,37,0,M|41,38,0,M|41,39,0,M|41,40,0,M|41,41,0,M|41,42,0,M|41,43,0,M|42,35,0,M|42,36,0,M|42,37,0,M|42,38,0,M|42,39,0,M|42,40,0,M|42,41,0,M|42,42,0,M|42,43,0,M|43,35,0,M|43,36,0,M|43,37,0,M|43,38,0,M|43,39,0,M|43,40,0,M|43,41,0,M|43,42,0,M|43,43,0,M|44,35,0,M|44,36,0,M|44,37,0,M|44,38,0,M|44,39,0,M|44,40,0,M|44,41,0,M|44,42,0,M|44,43,0,M|45,35,0,M|45,36,0,M|45,37,0,M|45,38,0,M|45,39,0,M|45,40,0,M|45,41,0,M|45,42,0,M|45,43,0,M|44,45,0,P|43,45,2,_|45,45,2,_|44,44,0,M|48,41,0,P|46,42,0,N|37,41,0,N|38,41,0,N|40,41,0,N|41,41,0,N|42,41,0,N|42,34,0,N|42,35,0,N|42,36,0,N|42,37,0,N|42,38,0,N|42,39,0,N|42,40,0,N|42,42,0,N|42,43,0,N|45,41,0,N|44,34,0,P|44,41,0,P|43,35,0,R|45,35,0,R|41,36,3,`|41,39,3,`|37,39,1,`|37,36,1,`|39,41,0,P|43,36,0,a|45,36,0,a|43,34,0,O|43,41,0,O|32,23,0,b|40,21,1,b|34,20,0,b|37,15,3,b|30,25,2,b|25,23,0,b|23,25,2,b|18,21,1,b|20,17,3,b|32,29,2,b|40,31,1,b|27,17,2,b|40,25,2,b|41,14,3,b|39,10,0,b|10,21,1,b|8,14,0,b|16,14,0,b|61,32,2,b|61,20,0,b|55,32,2,b|55,20,0,b|47,42,2,b|50,14,1,b|37,38,3,b|20,35,3,b|25,29,2,b|10,31,1,b|18,31,1,b|27,35,0,b|16,38,2,b|8,38,2,b|34,32,2,b|44,9,2,b|70,32,2,b|76,30,0,b|80,32,2,b|90,23,2,b|80,20,0,b|86,17,3,b|74,22,2,b|70,20,0,b|95,18,1,b|98,21,0,b|100,23,2,b|90,29,0,b|98,31,2,b|100,29,0,b|95,34,1,b|86,35,3,b|62,30,0,c|62,22,2,c|58,35,2,b|59,27,3,c|59,26,3,b|58,17,0,b|47,38,3,b|46,33,0,b|46,19,2,b|48,10,0,b|40,42,2,b|43,38,3,b|43,43,3,b|48,12,0,d|50,36,3,e|50,39,3,e|30,26,0,M|30,26,0,X|74,23,0,M|74,22,1,d|74,23,0,X|60,18,2,O|60,34,0,O|50,24,0,M|51,25,0,M|51,27,0,M|50,28,0,M|51,30,0,M|51,22,0,M|47,22,2,b|47,30,0,b|42,27,3,b|42,22,0,M|42,23,0,M|42,24,0,M|42,25,0,M|42,26,0,M|42,27,0,M|43,22,0,M|43,24,0,M|43,25,0,M|43,26,0,M|43,27,0,M|44,22,0,M|44,23,0,M|44,24,0,M|44,25,0,M|44,26,0,M|44,27,0,M|45,22,0,M|45,23,0,M|45,24,0,M|45,26,0,M|45,28,0,M|46,22,0,M|46,23,0,M|46,24,0,M|46,26,0,M|46,28,0,M|46,29,0,M|47,22,0,M|47,23,0,M|47,24,0,M|47,25,0,M|47,27,0,M|47,28,0,M|47,29,0,M|47,30,0,M|48,22,0,M|48,23,0,M|48,24,0,M|48,26,0,M|48,28,0,M|48,29,0,M|48,30,0,M|49,22,0,M|49,25,0,M|49,26,0,M|49,27,0,M|49,28,0,M|49,30,0,M|50,22,0,M|50,25,0,M|50,26,0,M|50,27,0,M|50,30,0,M|45,23,3,f|45,22,0,g|47,22,0,g|42,27,0,g|42,25,0,g|47,30,0,g|45,27,0,M|45,25,0,M|43,23,0,M|52,22,0,M|52,23,0,M|52,25,0,M|52,26,0,M|52,27,0,M|52,29,0,M|52,30,0,M|51,24,0,M|51,28,0,M|54,26,3,O|54,27,0,N|54,28,0,N|54,29,0,N|54,30,0,N|53,28,0,N|54,22,0,N|54,23,0,N|54,24,0,N|54,25,0,N|53,24,0,N|53,22,0,M|53,23,0,M|52,24,0,M|53,25,0,M|53,26,0,M|53,27,0,M|52,28,0,M|53,29,0,M|53,30,0,M|50,23,0,M|51,23,0,M|48,25,0,M|47,26,0,M|48,27,0,M|49,29,0,M|50,29,0,M|51,29,0,M|49,29,0,f|51,29,1,f|51,23,1,f|49,23,0,M|49,24,0,M|42,28,0,M|43,28,0,M|44,28,0,M|42,29,0,M|43,29,0,M|44,29,0,M|45,29,0,M|42,30,0,M|43,30,0,M|44,30,0,M|45,30,0,M|46,30,0,M|43,28,0,f|45,30,0,g|49,25,0,h|49,27,0,h|55,23,0,M|55,24,0,M|55,25,0,M|55,26,0,M|55,27,0,M|55,28,0,M|55,30,0,M|56,22,0,M|56,23,0,M|56,24,0,M|56,25,0,M|56,26,0,M|56,27,0,M|56,28,0,M|56,29,0,M|56,30,0,M|57,23,0,M|57,24,0,M|57,25,0,M|57,26,0,M|57,27,0,M|57,28,0,M|57,29,0,M|57,30,0,M|40,30,2,i|41,17,1,j|41,13,1,k|41,11,1,j|31,16,3,l|37,21,0,i|37,19,0,i|37,17,1,j|19,10,3,l|25,25,3,j|37,30,0,i|43,11,1,m|25,13,3,l|21,11,3,l|23,12,3,l|28,21,3,j|27,14,3,l|29,15,3,l|40,23,2,i|35,19,3,j|37,15,1,j|10,23,3,j|13,23,3,n|16,23,2,j|15,21,0,j|13,21,3,n|10,20,3,j|10,18,3,j|3,14,0,o|7,11,3,n|16,12,2,n|17,9,3,l|15,14,2,j|13,14,2,j|3,37,0,l|16,43,1,o|18,42,1,o|20,41,1,o|22,40,1,o|24,39,1,o|26,38,1,o|28,37,1,o|30,36,1,o|62,33,1,i|63,19,3,i|54,33,1,i|55,19,3,i|48,43,2,j|45,19,3,i|50,37,3,p|50,35,3,p|49,19,3,i|50,38,3,p|50,40,3,p|35,32,3,j|10,33,3,j|10,31,3,j|13,29,3,n|15,29,0,j|28,30,3,j|13,31,3,n|16,31,2,j|7,41,3,n|16,41,2,n|12,38,0,j|14,38,0,j|96,35,3,n|81,33,1,i|68,33,1,i|95,33,3,j|87,29,3,n|76,29,3,j|74,30,1,j|76,22,3,j|87,23,3,n|82,19,3,i|69,19,3,i|95,18,3,j|96,17,3,n|25,36,2,j|10,28,3,j|27,35,2,j|23,37,2,j|43,43,1,j|41,35,3,q|41,37,3,q|41,38,3,q|41,40,3,q|37,40,1,q|37,38,1,q|37,37,1,q|37,35,1,q|32,20,1,j|32,33,1,j|37,32,0,i|49,12,0,r|47,36,1,j|47,40,1,j|32,26,3,j|53,23,1,s|53,30,1,s|38,10,2,t|9,15,0,u|18,13,2,t|6,14,2,v|5,12,2,t|8,11,0,u|10,11,0,u|12,11,0,u|14,11,0,w|58,44,0,u|58,42,0,u|58,40,0,u|58,38,0,u|58,36,0,u|58,15,0,u|58,13,0,u|58,11,0,u|58,9,0,u|58,7,0,u|50,43,2,t|44,13,0,x|48,15,0,y|50,10,2,t|9,36,0,u|6,39,2,v|5,41,2,t|8,40,0,u|10,40,0,u|12,40,0,u|14,40,0,w|18,40,2,t|96,39,2,t|96,37,2,t|98,33,2,v|100,33,2,v|100,20,2,v|98,20,2,v|96,16,2,t|96,14,2,t|37,42,0,t|39,13,1,z|1,13,1,{|0,10,0,{|1,39,3,}|0,42,0,}|49,51,0,{|49,1,0,}|30,33,1,~|20,32,3,|20,15,3,|67,51,2,}|84,40,0,}|98,40,2,{|108,30,2,{|84,12,0,{|98,12,2,}|108,22,2,}|67,1,2,{|53,26,3,|52,23,3,|52,29,3,|49,30,2,|43,30,2,|47,26,1,|61,28,0,|61,23,0,|59,28,0,|59,23,0,|64,28,0,|64,23,0,|62,28,0,|62,23,0,|34,26,0,|21,26,0,|28,26,0,|29,19,0,|75,26,0,|43,23,1,|103,26,1,|102,26,1,|101,26,1,|100,26,1,|99,26,1,|98,26,1,|97,26,1,|96,26,1,|95,26,1,|94,26,1,|93,26,1,|104,26,1,|105,26,1,|21,36,3,|62,48,0,|62,44,0,|62,40,0,|62,36,0,|62,15,0,|62,11,0,|62,7,0,|62,3,0,|58,48,0,|54,48,0,|54,44,0,|54,40,0,|54,36,0,|54,15,0,|54,11,0,|54,7,0,|54,3,0,|58,3,0,|87,26,2,|91,26,1,|107,26,1,|80,29,0,|69,29,0,|69,26,0,|80,26,0,|69,23,0,|80,23,0,|23,19,0,|14,26,0,|5,23,1,|5,18,1,|14,18,0,|5,29,1,|5,34,1,|14,34,0,|90,35,0,|90,17,0,|51,26,0,M|46,27,0,M|46,25,0,M|56,31,0,P|56,21,0,P|57,31,2,O|57,26,1,b|54,31,0,N|54,21,0,N|57,25,3,|56,27,0,s|57,28,2,|57,24,3,|55,29,0,M|46,27,0,|46,25,0,|57,22,0,M|55,22,0,M|41,9,0,|42,9,0,|43,9,0,|44,9,0,|45,9,0,|46,9,0,|41,10,0,|42,10,0,|43,10,0,|44,10,0,|45,10,0,|46,10,0,|41,11,0,|42,11,0,|43,11,0,|44,11,0,|45,11,0,|46,11,0,|37,12,0,|38,12,0,|39,12,0,|41,12,0,|42,12,0,|43,12,0,|44,12,0,|45,12,0,|46,12,0,|47,12,0,|48,12,0,|49,12,0,|50,12,0,|37,13,0,|38,13,0,|39,13,0,|41,13,0,|42,13,0,|43,13,0,|44,13,0,|45,13,0,|46,13,0,|47,13,0,|48,13,0,|49,13,0,|50,13,0,|86,13,0,|87,13,0,|88,13,0,|89,13,0,|90,13,0,|91,13,0,|92,13,0,|93,13,0,|94,13,0,|95,13,0,|96,13,0,|20,14,0,|21,14,0,|37,14,0,|38,14,0,|39,14,0,|41,14,0,|42,14,0,|43,14,0,|44,14,0,|45,14,0,|46,14,0,|47,14,0,|48,14,0,|49,14,0,|50,14,0,|86,14,0,|87,14,0,|88,14,0,|89,14,0,|90,14,0,|91,14,0,|92,14,0,|93,14,0,|94,14,0,|95,14,0,|96,14,0,|20,15,0,|21,15,0,|22,15,0,|23,15,0,|37,15,0,|38,15,0,|39,15,0,|41,15,0,|42,15,0,|43,15,0,|44,15,0,|45,15,0,|46,15,0,|47,15,0,|48,15,0,|49,15,0,|50,15,0,|86,15,0,|87,15,0,|88,15,0,|89,15,0,|90,15,0,|91,15,0,|92,15,0,|93,15,0,|94,15,0,|95,15,0,|96,15,0,|20,16,0,|21,16,0,|22,16,0,|23,16,0,|24,16,0,|25,16,0,|37,16,0,|38,16,0,|39,16,0,|41,16,0,|42,16,0,|43,16,0,|44,16,0,|45,16,0,|46,16,0,|47,16,0,|48,16,0,|49,16,0,|50,16,0,|86,16,0,|87,16,0,|88,16,0,|89,16,0,|90,16,0,|91,16,0,|92,16,0,|93,16,0,|94,16,0,|95,16,0,|96,16,0,|20,17,0,|21,17,0,|22,17,0,|23,17,0,|24,17,0,|25,17,0,|26,17,0,|27,17,0,|37,17,0,|38,17,0,|39,17,0,|41,17,0,|42,17,0,|43,17,0,|44,17,0,|45,17,0,|46,17,0,|47,17,0,|48,17,0,|49,17,0,|50,17,0,|86,17,0,|87,17,0,|88,17,0,|89,17,0,|90,17,0,|91,17,0,|92,17,0,|93,17,0,|94,17,0,|95,17,0,|96,17,0,|20,18,0,|21,18,0,|22,18,0,|23,18,0,|24,18,0,|25,18,0,|26,18,0,|27,18,0,|28,18,0,|29,18,0,|30,18,0,|86,18,0,|87,18,0,|88,18,0,|89,18,0,|90,18,0,|91,18,0,|92,18,0,|93,18,0,|94,18,0,|95,18,0,|20,19,0,|21,19,0,|22,19,0,|23,19,0,|24,19,0,|25,19,0,|26,19,0,|27,19,0,|28,19,0,|29,19,0,|30,19,0,|37,19,0,|38,19,0,|39,19,0,|40,19,0,|41,19,0,|42,19,0,|43,19,0,|44,19,0,|45,19,0,|46,19,0,|47,19,0,|48,19,0,|49,19,0,|50,19,0,|53,19,0,|54,19,0,|55,19,0,|56,19,0,|57,19,0,|58,19,0,|59,19,0,|60,19,0,|61,19,0,|62,19,0,|63,19,0,|64,19,0,|67,19,0,|68,19,0,|69,19,0,|70,19,0,|71,19,0,|72,19,0,|73,19,0,|74,19,0,|75,19,0,|76,19,0,|77,19,0,|78,19,0,|79,19,0,|80,19,0,|81,19,0,|82,19,0,|83,19,0,|86,19,0,|87,19,0,|88,19,0,|89,19,0,|90,19,0,|91,19,0,|92,19,0,|93,19,0,|94,19,0,|95,19,0,|20,20,0,|21,20,0,|22,20,0,|23,20,0,|24,20,0,|25,20,0,|26,20,0,|27,20,0,|28,20,0,|29,20,0,|30,20,0,|37,20,0,|38,20,0,|39,20,0,|40,20,0,|41,20,0,|42,20,0,|43,20,0,|44,20,0,|45,20,0,|46,20,0,|47,20,0,|48,20,0,|49,20,0,|50,20,0,|52,20,0,|53,20,0,|54,20,0,|55,20,0,|56,20,0,|57,20,0,|58,20,0,|59,20,0,|60,20,0,|61,20,0,|62,20,0,|63,20,0,|64,20,0,|66,20,0,|67,20,0,|68,20,0,|69,20,0,|70,20,0,|71,20,0,|72,20,0,|73,20,0,|74,20,0,|75,20,0,|76,20,0,|77,20,0,|78,20,0,|79,20,0,|80,20,0,|81,20,0,|82,20,0,|83,20,0,|84,20,0,|86,20,0,|87,20,0,|88,20,0,|89,20,0,|90,20,0,|91,20,0,|92,20,0,|93,20,0,|94,20,0,|95,20,0,|20,21,0,|21,21,0,|22,21,0,|23,21,0,|24,21,0,|25,21,0,|26,21,0,|27,21,0,|28,21,0,|37,21,0,|38,21,0,|39,21,0,|40,21,0,|86,21,0,|87,21,0,|88,21,0,|89,21,0,|90,21,0,|91,21,0,|92,21,0,|93,21,0,|94,21,0,|95,21,0,|20,22,0,|21,22,0,|22,22,0,|23,22,0,|24,22,0,|25,22,0,|26,22,0,|27,22,0,|28,22,0,|30,22,0,|31,22,0,|32,22,0,|33,22,0,|34,22,0,|35,22,0,|37,22,0,|38,22,0,|39,22,0,|40,22,0,|42,22,0,|43,22,0,|44,22,0,|45,22,0,|46,22,0,|47,22,0,|48,22,0,|49,22,0,|50,22,0,|51,22,0,|52,22,0,|53,22,0,|55,22,0,|56,22,0,|57,22,0,|20,23,0,|21,23,0,|22,23,0,|23,23,0,|24,23,0,|25,23,0,|26,23,0,|27,23,0,|28,23,0,|30,23,0,|31,23,0,|32,23,0,|33,23,0,|34,23,0,|35,23,0,|37,23,0,|38,23,0,|39,23,0,|40,23,0,|42,23,0,|43,23,0,|44,23,0,|45,23,0,|46,23,0,|47,23,0,|48,23,0,|49,23,0,|50,23,0,|51,23,0,|52,23,0,|53,23,0,|55,23,0,|56,23,0,|57,23,0,|42,24,0,|43,24,0,|44,24,0,|45,24,0,|46,24,0,|47,24,0,|48,24,0,|49,24,0,|50,24,0,|51,24,0,|52,24,0,|55,24,0,|56,24,0,|57,24,0,|42,25,0,|43,25,0,|44,25,0,|45,25,0,|46,25,0,|47,25,0,|48,25,0,|49,25,0,|50,25,0,|51,25,0,|52,25,0,|53,25,0,|55,25,0,|56,25,0,|57,25,0,|42,26,0,|43,26,0,|44,26,0,|45,26,0,|46,26,0,|47,26,0,|48,26,0,|49,26,0,|50,26,0,|51,26,0,|52,26,0,|53,26,0,|55,26,0,|56,26,0,|57,26,0,|42,27,0,|43,27,0,|44,27,0,|45,27,0,|46,27,0,|47,27,0,|48,27,0,|49,27,0,|50,27,0,|51,27,0,|52,27,0,|53,27,0,|55,27,0,|56,27,0,|57,27,0,|42,28,0,|43,28,0,|44,28,0,|45,28,0,|46,28,0,|47,28,0,|48,28,0,|49,28,0,|50,28,0,|51,28,0,|52,28,0,|55,28,0,|56,28,0,|57,28,0,|20,29,0,|21,29,0,|22,29,0,|23,29,0,|24,29,0,|25,29,0,|26,29,0,|27,29,0,|28,29,0,|30,29,0,|31,29,0,|32,29,0,|33,29,0,|34,29,0,|35,29,0,|37,29,0,|38,29,0,|39,29,0,|40,29,0,|42,29,0,|43,29,0,|44,29,0,|45,29,0,|46,29,0,|47,29,0,|48,29,0,|49,29,0,|50,29,0,|51,29,0,|52,29,0,|53,29,0,|55,29,0,|56,29,0,|57,29,0,|20,30,0,|21,30,0,|22,30,0,|23,30,0,|24,30,0,|25,30,0,|26,30,0,|27,30,0,|28,30,0,|30,30,0,|31,30,0,|32,30,0,|33,30,0,|34,30,0,|35,30,0,|37,30,0,|38,30,0,|39,30,0,|40,30,0,|42,30,0,|43,30,0,|44,30,0,|45,30,0,|46,30,0,|47,30,0,|48,30,0,|49,30,0,|50,30,0,|51,30,0,|52,30,0,|53,30,0,|55,30,0,|56,30,0,|57,30,0,|20,31,0,|21,31,0,|22,31,0,|23,31,0,|24,31,0,|25,31,0,|26,31,0,|27,31,0,|28,31,0,|37,31,0,|38,31,0,|39,31,0,|40,31,0,|86,31,0,|87,31,0,|88,31,0,|89,31,0,|90,31,0,|91,31,0,|92,31,0,|93,31,0,|94,31,0,|95,31,0,|20,32,0,|21,32,0,|22,32,0,|23,32,0,|24,32,0,|25,32,0,|26,32,0,|27,32,0,|28,32,0,|29,32,0,|30,32,0,|37,32,0,|38,32,0,|39,32,0,|40,32,0,|41,32,0,|42,32,0,|43,32,0,|44,32,0,|45,32,0,|46,32,0,|47,32,0,|48,32,0,|49,32,0,|50,32,0,|52,32,0,|53,32,0,|54,32,0,|55,32,0,|56,32,0,|57,32,0,|58,32,0,|59,32,0,|60,32,0,|61,32,0,|62,32,0,|63,32,0,|64,32,0,|66,32,0,|67,32,0,|68,32,0,|69,32,0,|70,32,0,|71,32,0,|72,32,0,|73,32,0,|74,32,0,|75,32,0,|76,32,0,|77,32,0,|78,32,0,|79,32,0,|80,32,0,|81,32,0,|82,32,0,|83,32,0,|84,32,0,|86,32,0,|87,32,0,|88,32,0,|89,32,0,|90,32,0,|91,32,0,|92,32,0,|93,32,0,|94,32,0,|95,32,0,|20,33,0,|21,33,0,|22,33,0,|23,33,0,|24,33,0,|25,33,0,|26,33,0,|27,33,0,|28,33,0,|29,33,0,|30,33,0,|37,33,0,|38,33,0,|39,33,0,|40,33,0,|41,33,0,|42,33,0,|43,33,0,|44,33,0,|45,33,0,|46,33,0,|47,33,0,|48,33,0,|49,33,0,|50,33,0,|53,33,0,|54,33,0,|55,33,0,|56,33,0,|57,33,0,|58,33,0,|59,33,0,|60,33,0,|61,33,0,|62,33,0,|63,33,0,|64,33,0,|67,33,0,|68,33,0,|69,33,0,|70,33,0,|71,33,0,|72,33,0,|73,33,0,|74,33,0,|75,33,0,|76,33,0,|77,33,0,|78,33,0,|79,33,0,|80,33,0,|81,33,0,|82,33,0,|83,33,0,|86,33,0,|87,33,0,|88,33,0,|89,33,0,|90,33,0,|91,33,0,|92,33,0,|93,33,0,|94,33,0,|95,33,0,|20,34,0,|21,34,0,|22,34,0,|23,34,0,|24,34,0,|25,34,0,|26,34,0,|27,34,0,|28,34,0,|29,34,0,|30,34,0,|86,34,0,|87,34,0,|88,34,0,|89,34,0,|90,34,0,|91,34,0,|92,34,0,|93,34,0,|94,34,0,|95,34,0,|20,35,0,|21,35,0,|22,35,0,|23,35,0,|24,35,0,|25,35,0,|26,35,0,|27,35,0,|37,35,0,|38,35,0,|39,35,0,|40,35,0,|41,35,0,|43,35,0,|44,35,0,|45,35,0,|47,35,0,|48,35,0,|49,35,0,|50,35,0,|86,35,0,|87,35,0,|88,35,0,|89,35,0,|90,35,0,|91,35,0,|92,35,0,|93,35,0,|94,35,0,|95,35,0,|96,35,0,|20,36,0,|21,36,0,|22,36,0,|23,36,0,|24,36,0,|25,36,0,|37,36,0,|38,36,0,|39,36,0,|40,36,0,|41,36,0,|43,36,0,|44,36,0,|45,36,0,|47,36,0,|48,36,0,|49,36,0,|50,36,0,|86,36,0,|87,36,0,|88,36,0,|89,36,0,|90,36,0,|91,36,0,|92,36,0,|93,36,0,|94,36,0,|95,36,0,|96,36,0,|20,37,0,|21,37,0,|22,37,0,|23,37,0,|37,37,0,|38,37,0,|39,37,0,|40,37,0,|41,37,0,|43,37,0,|44,37,0,|45,37,0,|47,37,0,|48,37,0,|49,37,0,|50,37,0,|86,37,0,|87,37,0,|88,37,0,|89,37,0,|90,37,0,|91,37,0,|92,37,0,|93,37,0,|94,37,0,|95,37,0,|96,37,0,|20,38,0,|21,38,0,|37,38,0,|38,38,0,|39,38,0,|40,38,0,|41,38,0,|43,38,0,|44,38,0,|45,38,0,|47,38,0,|48,38,0,|49,38,0,|50,38,0,|86,38,0,|87,38,0,|88,38,0,|89,38,0,|90,38,0,|91,38,0,|92,38,0,|93,38,0,|94,38,0,|95,38,0,|96,38,0,|37,39,0,|38,39,0,|39,39,0,|40,39,0,|41,39,0,|43,39,0,|44,39,0,|45,39,0,|47,39,0,|48,39,0,|49,39,0,|50,39,0,|86,39,0,|87,39,0,|88,39,0,|89,39,0,|90,39,0,|91,39,0,|92,39,0,|93,39,0,|94,39,0,|95,39,0,|96,39,0,|37,40,0,|38,40,0,|39,40,0,|40,40,0,|41,40,0,|43,40,0,|44,40,0,|45,40,0,|47,40,0,|48,40,0,|49,40,0,|50,40,0,|43,42,0,|44,42,0,|45,42,0,|43,43,0,|44,43,0,|45,43,0,|44,44,0,</bigString>
 	</SaveOurShip2.ShipDef>
 </Defs>


### PR DESCRIPTION
Modifies the ship throne room and bedroom to meet the minimum requirements for the players title that they would receive the ship at.

The throne room may be undignified due to RNG on the quality of the furniture (normal quality was used for the baseline). This can be fixed by the player rebuilding it, which is easier than trying to re-design the room to fit the requirements.