### PR TITLE
archotechlungNoCEfix

### DIFF
--- a/1.5/Patches/patch_mod.xml
+++ b/1.5/Patches/patch_mod.xml
@@ -88,4 +88,16 @@
 			</value>
 		</match>
 	</Operation>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Combat Extended</li>
+		</mods>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/HediffDef[defName="SoSArchotechLung"]/stages/li/statOffsets</xpath>
+			<value>
+				<ToxicEnvironmentResistance MayRequire="Ludeon.RimWorld.Biotech">0.5</ToxicEnvironmentResistance>
+			</value>
+		</nomatch>
+	</Operation>
 </Patch>


### PR DESCRIPTION
Patch checks if combat extended is in the modlist. If not, it then patches archotech lungs to provide 0.5 ToxicEnviromentResistance to protect against effects such as lung rot.