### PR TITLE
Fix MapHelper.TryLinkMapToWorldObject throwing InvalidOperationException

### DIFF
--- a/Source/1.5/ShipInteriorMod2.cs
+++ b/Source/1.5/ShipInteriorMod2.cs
@@ -3316,7 +3316,7 @@ namespace SaveOurShip2
 		{
 			// For now, issue was found with Escape Ship map due to that map not being linked to world object
 			// So, fixing onlyy that case for now
-			WorldObject worldObject = Find.WorldObjects.ObjectsAt(tile).Where(t => t is EscapeShip).First();
+			WorldObject worldObject = Find.WorldObjects.ObjectsAt(tile).FirstOrDefault(t => t is EscapeShip);
 			if (worldObject != null && worldObject.Faction != Faction.OfPlayer)
 			{
 				// Link map to Escap ship object sho that it gets "Home" icon and when selected on world map, there is Abadon option 


### PR DESCRIPTION
It looks like it's supposed to do nothing when there isn't a worldObject that is an EscapeShip.

This makes it actually do nothing instead of throwing an exception when there is no worldObject on the tile that is an EscapeShip

This was encountered when I sent a shuttle to a RimNauts asteroid map and the shuttle just disappeared, and the map stayed fogged.

Fixes this issue caused by this exception:
```
Exception in Verse.LongEventHandler.UpdateCurrentSynchronousEvent: System.InvalidOperationException: Sequence contains no elements
[Ref BCB205B4]
 at System.Linq.Enumerable.First[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x00010] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
 at SaveOurShip2.MapHelper.TryLinkMapToWorldObject (Verse.Map map, System.Int32 tile) [0x00030] in <0ac025b09b37486d82eecc56888c58b0>:0 
 at SaveOurShip2.Vehicles.AerialVehicleArrivalAction_LoadMapAndDefog+<>c__DisplayClass2_0.<Arrived>b__0 () [0x00019] in <0ac025b09b37486d82eecc56888c58b0>:0 
 at Verse.LongEventHandler.UpdateCurrentSynchronousEvent (System.Boolean& sceneChanged) [0x00027] in <69945a8ed6c540cf90b578de735e0605>:0 
     - TRANSPILER net.pardeike.rimworld.lib.harmony: IEnumerable`1 VisualExceptions.ExceptionsAndActivatorHandler:Transpiler(IEnumerable`1 instructions, MethodBase original)
```